### PR TITLE
use uint{32,64}_t, ul and size_t consistently

### DIFF
--- a/libgalois/include/galois/graphs/B_LC_CSR_Graph.h
+++ b/libgalois/include/galois/graphs/B_LC_CSR_Graph.h
@@ -122,7 +122,7 @@ protected:
   void determineInEdgeIndices(EdgeIndData& dataBuffer) {
     // counting outgoing edges in the tranpose graph by
     // counting incoming edges in the original graph
-    galois::do_all(galois::iterate(0ul, BaseGraph::numEdges), [&](uint64_t e) {
+    galois::do_all(galois::iterate(UINT64_C(0), BaseGraph::numEdges), [&](uint64_t e) {
       auto dst = BaseGraph::edgeDst[e];
       __sync_add_and_fetch(&(dataBuffer[dst]), 1);
     });
@@ -134,8 +134,8 @@ protected:
 
     // copy over the new tranposed edge index data
     inEdgeIndData.allocateInterleaved(BaseGraph::numNodes);
-    galois::do_all(galois::iterate(0ul, BaseGraph::numNodes),
-                   [&](uint32_t n) { inEdgeIndData[n] = dataBuffer[n]; });
+    galois::do_all(galois::iterate(UINT64_C(0), BaseGraph::numNodes),
+                   [&](uint64_t n) { inEdgeIndData[n] = dataBuffer[n]; });
   }
 
   /**
@@ -150,8 +150,8 @@ protected:
     // saving an edge for a node
     if (BaseGraph::numNodes >= 1) {
       dataBuffer[0] = 0;
-      galois::do_all(galois::iterate(1ul, BaseGraph::numNodes),
-                     [&](uint32_t n) { dataBuffer[n] = inEdgeIndData[n - 1]; });
+      galois::do_all(galois::iterate(UINT64_C(1), BaseGraph::numNodes),
+                     [&](uint64_t n) { dataBuffer[n] = inEdgeIndData[n - 1]; });
     }
 
     // allocate edge dests and data
@@ -162,7 +162,7 @@ protected:
     }
 
     galois::do_all(
-        galois::iterate(0ul, BaseGraph::numNodes), [&](uint32_t src) {
+        galois::iterate(UINT64_C(0), BaseGraph::numNodes), [&](uint64_t src) {
           // e = start index into edge array for a particular node
           uint64_t e = (src == 0) ? 0 : BaseGraph::edgeIndData[src - 1];
 
@@ -213,8 +213,8 @@ public:
     // initialize the temp array
     EdgeIndData dataBuffer;
     dataBuffer.allocateInterleaved(BaseGraph::numNodes);
-    galois::do_all(galois::iterate(0ul, BaseGraph::numNodes),
-                   [&](uint32_t n) { dataBuffer[n] = 0; });
+    galois::do_all(galois::iterate(UINT64_C(0), BaseGraph::numNodes),
+                   [&](uint64_t n) { dataBuffer[n] = 0; });
 
     determineInEdgeIndices(dataBuffer);
     determineInEdgeDestAndData(dataBuffer);

--- a/lonestar/betweennesscentrality/BetweennessCentralityAsync.cpp
+++ b/lonestar/betweennesscentrality/BetweennessCentralityAsync.cpp
@@ -458,7 +458,7 @@ int main(int argc, char** argv) {
   // reset everything in preparation for run
   galois::do_all(galois::iterate(0u, nnodes),
                  [&](auto i) { bcGraph.getData(i).reset(); });
-  galois::do_all(galois::iterate(0ul, nedges),
+  galois::do_all(galois::iterate(UINT64_C(0), nedges),
                  [&](auto i) { bcGraph.getEdgeData(i).reset(); });
 
   // reading in list of sources to operate on if provided

--- a/lonestar/betweennesscentrality/BetweennessCentralityLevel.cpp
+++ b/lonestar/betweennesscentrality/BetweennessCentralityLevel.cpp
@@ -319,7 +319,7 @@ int main(int argc, char** argv) {
   galois::StatTimer preallocTime("PreAllocTime", REGION_NAME);
   preallocTime.start();
   galois::preAlloc(std::max(
-    (uint64_t)galois::getActiveThreads() * (graph.size() / 2000000),
+    (size_t)galois::getActiveThreads() * (graph.size() / 2000000),
     std::max(10u, galois::getActiveThreads()) * (size_t)10
   ));
   preallocTime.stop();

--- a/lonestar/kcore/kcore.cpp
+++ b/lonestar/kcore/kcore.cpp
@@ -262,7 +262,7 @@ int main(int argc, char** argv) {
   galois::StatTimer preallocTime("PreAllocTime", REGION_NAME);
   preallocTime.start();
   galois::preAlloc(std::max(
-    (uint64_t)galois::getActiveThreads() * (graph.size() / 1000000),
+    (size_t)galois::getActiveThreads() * (graph.size() / 1000000),
     std::max(10u, galois::getActiveThreads()) * (size_t)10
   ));
   preallocTime.stop();


### PR DESCRIPTION
Although the final widths may be the same, on some platforms, size_t and
uint64_t are not interchangable because they have different nominal
types (e.g., unsigned long long versus unsigned long) and vice versa,
and this causes build failures on MacOS due to unmatched template
instantiations.