### PR TITLE
ignore compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ cscope.out
 tags
 .vscode
 .settings
+compile_commands.json
 
 /GPATH
 /GRTAGS


### PR DESCRIPTION
A common developer pattern is to symlink this file from a build tree
into a source tree.