### PR TITLE
remove dependency on endian.h

### DIFF
--- a/libgalois/include/galois/Endian.h
+++ b/libgalois/include/galois/Endian.h
@@ -21,12 +21,32 @@
 #define GALOIS_ENDIAN_H
 
 #include <cstdint>
-#ifndef _BSD_SOURCE
-#define _BSD_SOURCE 1
-#endif
-#include <endian.h>
 
 namespace galois {
+
+static inline uint32_t bswap32(uint32_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+  return __builtin_bswap32(x);
+#else
+  return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) |
+         ((x >> 8) & 0x0000ff00) | ((x >> 24) & 0x000000ff);
+#endif
+}
+
+static inline uint64_t bswap64(uint64_t x) {
+#if defined(__GNUC__) || defined(__clang__)
+  return __builtin_bswap64(x);
+#else
+  return ((x << 56) & 0xff00000000000000UL) |
+         ((x << 40) & 0x00ff000000000000UL) |
+         ((x << 24) & 0x0000ff0000000000UL) |
+         ((x <<  8) & 0x000000ff00000000UL) |
+         ((x >>  8) & 0x00000000ff000000UL) |
+         ((x >> 24) & 0x0000000000ff0000UL) |
+         ((x >> 40) & 0x000000000000ff00UL) |
+         ((x >> 56) & 0x00000000000000ffUL);
+#endif
+}
 
 // NB: Wrap these standard functions with different names because
 // sometimes le64toh and such are implemented as macros and we don't
@@ -35,7 +55,7 @@ static inline uint64_t convert_le64toh(uint64_t x) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return x;
 #else
-  return le64toh(x);
+  return bswap64(x);
 #endif
 }
 
@@ -43,7 +63,7 @@ static inline uint32_t convert_le32toh(uint32_t x) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return x;
 #else
-  return le32toh(x);
+  return bswap32(x);
 #endif
 }
 
@@ -51,7 +71,7 @@ static inline uint64_t convert_htobe64(uint64_t x) {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   return x;
 #else
-  return htobe64(x);
+  return bswap64(x);
 #endif
 }
 
@@ -59,7 +79,7 @@ static inline uint32_t convert_htobe32(uint32_t x) {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
   return x;
 #else
-  return htobe32(x);
+  return bswap32(x);
 #endif
 }
 
@@ -67,7 +87,7 @@ static inline uint64_t convert_htole64(uint64_t x) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return x;
 #else
-  return htole64(x);
+  return bswap64(x);
 #endif
 }
 
@@ -75,23 +95,8 @@ static inline uint32_t convert_htole32(uint32_t x) {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   return x;
 #else
-  return htole32(x);
+  return bswap32(x);
 #endif
-}
-
-static inline uint32_t bswap32(uint32_t x) {
-  return ((x << 24) & 0xff000000) | ((x << 8) & 0x00ff0000) |
-         ((x >> 8) & 0x0000ff00) | ((x >> 24) & 0x000000ff);
-}
-
-static inline uint64_t bswap64(uint64_t x) {
-  return ((x << 56) & 0xff00000000000000UL) |
-         ((x << 40) & 0x00ff000000000000UL) |
-         ((x << 24) & 0x0000ff0000000000UL) |
-         ((x << 8) & 0x000000ff00000000UL) | ((x >> 8) & 0x00000000ff000000UL) |
-         ((x >> 24) & 0x0000000000ff0000UL) |
-         ((x >> 40) & 0x000000000000ff00UL) |
-         ((x >> 56) & 0x00000000000000ffUL);
 }
 
 } // namespace galois


### PR DESCRIPTION
endian.h doesn't exist on MacOS, and we can get all the benefit via
__builtin_bswap{32,64}.