### PR TITLE
Add clang 10 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -207,16 +207,15 @@ matrix:
             - openmpi-bin
             - libopenmpi-dev
     - env:
-        - CLANG_VER=9
-        - BUILD_TYPE=Debug
+        - CLANG_VER=10
       addons:
         apt:
           sources:
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
-            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-9
+            - clang-10
             - gcc-9
             - g++-9
             - cmake
@@ -225,7 +224,25 @@ matrix:
             - openmpi-bin
             - libopenmpi-dev
     - env:
-        - CLANG_VER=9
+        - CLANG_VER=10
+        - BUILD_TYPE=Debug
+      addons:
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+          packages:
+            - clang-10
+            - gcc-9
+            - g++-9
+            - cmake
+            - libboost-all-dev
+            - libeigen3-dev
+            - openmpi-bin
+            - libopenmpi-dev
+    - env:
+        - CLANG_VER=10
         # set -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR to avoid compiler errors in boost headers.
         # This comes from using a boost built with libstdc++ with libc++. None of the APIs we
         # use expose stdlib objects directly though, so the build still works in-spite of the
@@ -235,12 +252,12 @@ matrix:
         apt:
           sources:
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
-            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-9
-            - libc++-9-dev
-            - libc++abi-9-dev
+            - clang-10
+            - libc++-10-dev
+            - libc++abi-10-dev
             - gcc-9
             - g++-9
             - cmake
@@ -249,7 +266,7 @@ matrix:
             - openmpi-bin
             - libopenmpi-dev
     - env:
-        - CLANG_VER=9
+        - CLANG_VER=10
         - BUILD_TYPE=Debug
         # -D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR work around to avoid compiler errors
         # when using libc++ and boost together. See above.
@@ -258,12 +275,12 @@ matrix:
         apt:
           sources:
             - sourceline: 'ppa:ubuntu-toolchain-r/test'
-            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+            - sourceline: 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-9
-            - libc++-9-dev
-            - libc++abi-9-dev
+            - clang-10
+            - libc++-10-dev
+            - libc++abi-10-dev
             - gcc-9
             - g++-9
             - cmake


### PR DESCRIPTION
In anticipation of upcoming release. (Tests will probably fail until the binary packages are public).