### PR TITLE
Set _GNU_SOURCE when checking for sched_setaffinity

### DIFF
--- a/cmake/Modules/CheckSchedSetAffinity.cmake
+++ b/cmake/Modules/CheckSchedSetAffinity.cmake
@@ -3,6 +3,7 @@ include(CheckSymbolExists)
 if(SCHED_SETAFFINITY_FOUND)
 
 else()
+  set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
   CHECK_SYMBOL_EXISTS(sched_setaffinity sched.h HAVE_SCHED_SETAFFINITY_INTERNAL)
   if(HAVE_SCHED_SETAFFINITY_INTERNAL)
     message(STATUS "sched_setaffinity found")


### PR DESCRIPTION
This needs to be defined otherwise sched_setaffinity will never be
found.

Tested by:
- [x] spinning up a ubuntu container and running `cmake -DUSE_STRICT_CONFIG=on ..`
---

Looks like Arch has updated its boost package

  https://www.archlinux.org/packages/?sort=&q=boost&maintainer=&flagged=

(Jan 30), which I think is causing the build failure.
