### PR TITLE
Fix build on Arch Linux

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - checkout
       - run: |
           pacman -Sy
-          pacman -q -S --noconfirm gcc make cmake boost eigen openmpi
+          pacman -q -S --noconfirm gcc make cmake boost1.69 eigen openmpi
           mkdir build
           cd build
           cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DNUM_TEST_THREADS=2 -DENABLE_DIST_GALOIS=ON ..


### PR DESCRIPTION
The newer boost libraries 1.72 on Arch Linux only provide the
multithreaded variants. This causes a CMake configuration failure
because we explicitly set(BOOST_USE_MULTITHREADED OFF).

The most forward looking fix would be to remove the multithreaded
constraint but I'm not sure of the performance implications thereof. For
the time being to unblock the CI, just pin the boost library to a
previous version that does provide non-multithreaded variants.