### PR TITLE
Use Multithread Enabled Boost

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - checkout
       - run: |
           pacman -Sy
-          pacman -q -S --noconfirm gcc make cmake boost1.69 eigen openmpi
+          pacman -q -S --noconfirm gcc make cmake boost eigen openmpi
           mkdir build
           cd build
           cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Release -DNUM_TEST_THREADS=2 -DENABLE_DIST_GALOIS=ON ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,6 @@ endif()
 
 # Boost
 set(Boost_ADDITIONAL_VERSIONS "1.58.0" "1.60.0" "1.61.0" "1.62.0")
-set(Boost_USE_MULTITHREADED OFF)
 if(NOT "$ENV{BOOST_DIR}" STREQUAL "")
   set(BOOST_ROOT $ENV{BOOST_DIR})
 endif()


### PR DESCRIPTION
The boost multithreaded libraries really only provide very minimal thread safety guarantees and actually are the kinds of thing we want to use, not disable (https://stackoverflow.com/a/20991533/1935144).