### PR TITLE
Bump to C++17 standard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,10 @@ jobs:
       - checkout
       - run: |
           apt-get -q update -y
+          apt-get -q install -y apt-transport-https ca-certificates gnupg software-properties-common wget
+          wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
+          apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
+          apt-get -q update -y
           apt-get -q install -y libboost-all-dev libeigen3-dev cmake gcc g++ zlib1g-dev wget libopenmpi-dev openmpi-bin
           mkdir build
           cd build
@@ -141,7 +145,7 @@ jobs:
           conda install -y -q -c conda-forge make cmake boost-cpp clangdev=6 llvmdev=6 llvm-meta=6 libcxx=6 zlib eigen
           mkdir build
           cd build
-          cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-stdlib=libc++" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath=$HOME/miniconda/lib" -DCMAKE_BUILD_TYPE=Release -DNUM_TEST_THREADS=2 ..
+          cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_CXX_FLAGS="-stdlib=libc++ -DBOOST_NO_AUTO_PTR" -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath=$HOME/miniconda/lib" -DCMAKE_BUILD_TYPE=Release -DNUM_TEST_THREADS=2 ..
           make input
           make -j2
           make test || :

--- a/.travis.yml
+++ b/.travis.yml
@@ -226,7 +226,7 @@ matrix:
             - libopenmpi-dev
     - env:
         - CLANG_VER=9
-        - CXXFLAGS="-stdlib=libc++"
+        - CXXFLAGS="-stdlib=libc++ -DBOOST_NO_AUTO_PTR"
       addons:
         apt:
           sources:
@@ -247,7 +247,7 @@ matrix:
     - env:
         - CLANG_VER=9
         - BUILD_TYPE=Debug
-        - CXXFLAGS="-stdlib=libc++"
+        - CXXFLAGS="-stdlib=libc++ -DBOOST_NO_AUTO_PTR"
       addons:
         apt:
           sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 3.8)
 
 include(GNUInstallDirs)
 
@@ -165,7 +165,7 @@ if(USE_SANITIZER)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer -fno-optimize-sibling-calls")
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) #...without compiler extensions like gnu++11
 
@@ -327,7 +327,6 @@ if(NOT "$ENV{BOOST_DIR}" STREQUAL "")
 endif()
 find_package(Boost 1.58.0 REQUIRED COMPONENTS serialization iostreams)
 include_directories(${Boost_INCLUDE_DIR})
-add_definitions(-DBOOST_NO_AUTO_PTR)
 
 include(CheckEndian)
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ beware.
 
 At the minimum, Galois depends on the following software:
 
-- A modern C++ compiler compliant with the C++-14 standard (GCC >= 6.1, Intel >= 17.0, LLVM >= 4.0)
-- CMake (>= 3.2.3)
+- A modern C++ compiler compliant with the C++-17 standard (GCC >= 7, Intel >= 19.0.1, LLVM >= 4.0)
+- CMake (>= 3.8)
 - Boost library ( >= 1.58.0, we recommend building/installing the full library)
 
 


### PR DESCRIPTION
Recently there have been issues with aligned structures but without
aligned allocations. This can create segfaults as a compiler might
generate code assuming a certain alignment (e.g., vmovaps) but the
allocator does not preserve the same alignment [1].

This really seems to be an issue with ::operator new pre-C++17 and the
most stable fix is to move to a newer standard.

[1] https://stackoverflow.com/questions/52000359

Closes #69 