### PR TITLE
Re-enable O3 with clang.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,13 +89,6 @@ enable_testing()
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall")
 
-# Some apps break with -O3 on recent clang versions.
-# Tracking that down is a work in progress, so for the current release,
-# only use -O2 with clang.
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND "${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
-endif()
-
 # generate compile_commands.json
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
Rolls back our old partial fix for https://github.com/IntelligentSoftwareSystems/Galois/issues/81 since it's not actually helping much.