### PR TITLE
Don't error on newly introduced warnings

### DIFF
--- a/lonestar/bipart/CMakeLists.txt
+++ b/lonestar/bipart/CMakeLists.txt
@@ -1,2 +1,3 @@
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 app(bipart main.cpp Coarsening.cpp Refine.cpp Partitioning.cpp Metric.cpp)
 


### PR DESCRIPTION
This should give the app authors time to fix these issues while not leaving CI totally broken.