### PR TITLE
Move PerThreadTimer to galois::runtime

### DIFF
--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -45,6 +45,7 @@ set(sources
         src/ParaMeter.cpp
         src/DynamicBitset.cpp
         src/Tracer.cpp
+        src/ThreadTimer.cpp
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/libgalois/include/galois/runtime/Executor_OnEach.h
+++ b/libgalois/include/galois/runtime/Executor_OnEach.h
@@ -20,13 +20,14 @@
 #ifndef GALOIS_RUNTIME_EXECUTOR_ONEACH_H
 #define GALOIS_RUNTIME_EXECUTOR_ONEACH_H
 
+#include "galois/gIO.h"
 #include "galois/gtuple.h"
-#include "galois/Traits.h"
+#include "galois/Threads.h"
 #include "galois/Timer.h"
+#include "galois/Traits.h"
 #include "galois/runtime/OperatorReferenceTypes.h"
 #include "galois/runtime/Statistics.h"
-#include "galois/Threads.h"
-#include "galois/gIO.h"
+#include "galois/runtime/ThreadTimer.h"
 #include "galois/substrate/ThreadPool.h"
 
 #include <tuple>

--- a/libgalois/include/galois/runtime/ThreadTimer.h
+++ b/libgalois/include/galois/runtime/ThreadTimer.h
@@ -1,0 +1,87 @@
+#ifndef GALOIS_RUNTIME_THREADTIMER_H
+#define GALOIS_RUNTIME_THREADTIMER_H
+
+#include "galois/substrate/PerThreadStorage.h"
+
+#include <ctime>
+
+namespace galois::runtime {
+
+class ThreadTimer {
+  timespec start_;
+  timespec stop_;
+  uint64_t nsec_{0};
+
+public:
+  ThreadTimer() = default;
+
+  void start() { clock_gettime(CLOCK_THREAD_CPUTIME_ID, &start_); }
+
+  void stop() {
+    clock_gettime(CLOCK_THREAD_CPUTIME_ID, &stop_);
+    nsec_ += (stop_.tv_nsec - start_.tv_nsec);
+    nsec_ += ((stop_.tv_sec - start_.tv_sec) * 1000000000);
+  }
+
+  uint64_t get_nsec() const { return nsec_; }
+
+  uint64_t get_sec() const { return (nsec_ / 1000000000); }
+
+  uint64_t get_msec() const { return (nsec_ / 1000000); }
+};
+
+class ThreadTimers {
+protected:
+  substrate::PerThreadStorage<ThreadTimer> timers_;
+
+  void reportTimes(const char* category, const char* region);
+};
+
+template <bool enabled>
+class PerThreadTimer: private ThreadTimers {
+  const char* const region_;
+  const char* const category_;
+
+  void reportTimes() {
+    reportTimes(category_, region_);
+  }
+
+public:
+  PerThreadTimer(const char* const region,
+                 const char* const category)
+      : region_(region), category_(category) {}
+
+  PerThreadTimer(const PerThreadTimer&) = delete;
+  PerThreadTimer(PerThreadTimer&&) = delete;
+  PerThreadTimer& operator=(const PerThreadTimer&) = delete;
+  PerThreadTimer& operator=(PerThreadTimer&&) = delete;
+
+  ~PerThreadTimer() { reportTimes(); }
+
+  void start() { timers_.getLocal()->start(); }
+
+  void stop() { timers_.getLocal()->stop(); }
+};
+
+template <>
+class PerThreadTimer<false> {
+
+public:
+  PerThreadTimer(const char* const _region,
+                 const char* const _category) {}
+
+  PerThreadTimer(const PerThreadTimer&) = delete;
+  PerThreadTimer(PerThreadTimer&&) = delete;
+  PerThreadTimer& operator=(const PerThreadTimer&) = delete;
+  PerThreadTimer& operator=(PerThreadTimer&&) = delete;
+
+  ~PerThreadTimer() = default;
+
+  void start() const {}
+
+  void stop() const {}
+};
+
+}  // end namespace galois::runtime
+
+#endif

--- a/libgalois/src/ThreadTimer.cpp
+++ b/libgalois/src/ThreadTimer.cpp
@@ -1,0 +1,31 @@
+#include "galois/runtime/ThreadTimer.h"
+#include "galois/runtime/Executor_OnEach.h"
+#include "galois/runtime/Statistics.h"
+
+#include <ctime>
+#include <limits>
+
+void galois::runtime::ThreadTimers::reportTimes(const char* category,
+                                                const char* region) {
+
+  uint64_t minTime = std::numeric_limits<uint64_t>::max();
+
+  for (unsigned i = 0; i < timers_.size(); ++i) {
+    auto ns = timers_.getRemote(i)->get_nsec();
+    minTime = std::min(minTime, ns);
+  }
+
+  std::string timeCat = category + std::string("PerThreadTimes");
+  std::string lagCat  = category + std::string("PerThreadLag");
+
+  on_each_gen(
+      [&](auto a, auto b) {
+        auto ns  = timers_.getLocal()->get_nsec();
+        auto lag = ns - minTime;
+        assert(lag > 0 && "negative time lag from min is impossible");
+
+        reportStat_Tmax(region, timeCat.c_str(), ns / 1000000);
+        reportStat_Tmax(region, lagCat.c_str(), lag / 1000000);
+      },
+      std::make_tuple());
+}


### PR DESCRIPTION
Threads are a low-level primitive and the high-level galois namespace
should probably avoid frequent reference to it. Additionally
PerThreadTimer is (only) used by the runtime. We should minimize
dependencies from the galois::runtime to the galois namespace as ideally
the latter should be expressed in terms of the former rather than the
other way around.

Along the way, I moved as much implementation to the cpp file in an
effort to reduce include dependencies. Previously, Timer.h included both
ctime and chrono. Now it just includes chrono, the standard C++
definition of time.