### PR TITLE
Additional SPRoute Fixes

### DIFF
--- a/lonestar/eda/cpu/SPRoute/CMakeLists.txt
+++ b/lonestar/eda/cpu/SPRoute/CMakeLists.txt
@@ -5,4 +5,4 @@ add_dependencies(apps SPRoute)
 target_link_libraries(SPRoute PRIVATE Galois::shmem lonestar)
 install(TARGETS SPRoute DESTINATION "${CMAKE_INSTALL_BINDIR}" COMPONENT apps EXCLUDE_FROM_ALL)
 
-add_test_scale(small1 SPRoute "${BASEINPUT}/eda/routing/test.gr" --flute "${BASEINPUT}/eda/routing")
+add_test_scale(small1 SPRoute "${BASEINPUT}/eda/routing/test.gr" --flute "${BASEINPUT}/eda/routing" NOT_QUICK)

--- a/lonestar/eda/cpu/SPRoute/DataProc.h
+++ b/lonestar/eda/cpu/SPRoute/DataProc.h
@@ -223,7 +223,7 @@ void readFile(const char* benchFile) {
     nets[i]         = (Net*)malloc(sizeof(Net));
     invalid_nets[i] = (Net*)malloc(sizeof(Net));
   }
-  seglistIndex = (int*)malloc(numNets * sizeof(int));
+  seglistIndex = (int*)malloc((numNets + 1) * sizeof(int));
 
   // read nets information from the input file
   segcount      = 0;

--- a/lonestar/eda/cpu/SPRoute/main.cpp
+++ b/lonestar/eda/cpu/SPRoute/main.cpp
@@ -332,22 +332,18 @@ int main(int argc, char** argv) {
              max(OBIM_delta, (int)(costheight / (2 * slope))));
       // L = 2;
       roundtimer.start();
-      galois::runtime::profileVtune(
-          [&](void) {
-            round_num = i;
-            if (finegrain) {
-              printf("finegrain\n");
+      round_num = i;
+      if (finegrain) {
+        printf("finegrain\n");
 
-              mazeRouteMSMD_finegrain_spinlock(
-                  i, enlarge, costheight, ripup_threshold, mazeedge_Threshold,
-                  !(i % 3), cost_type, net_shuffle);
-            } else {
-              mazeRouteMSMD(i, enlarge, costheight, ripup_threshold,
-                            mazeedge_Threshold, !(i % 3), cost_type,
-                            net_shuffle);
-            }
-          },
-          "mazeroute");
+        mazeRouteMSMD_finegrain_spinlock(
+            i, enlarge, costheight, ripup_threshold, mazeedge_Threshold,
+            !(i % 3), cost_type, net_shuffle);
+      } else {
+        mazeRouteMSMD(i, enlarge, costheight, ripup_threshold,
+                      mazeedge_Threshold, !(i % 3), cost_type,
+                      net_shuffle);
+      }
       roundtimer.stop();
       cout << "round : " << i << " time(ms): " << roundtimer.get() - oldtime
            << " acc time(ms): " << roundtimer.get() << endl;

--- a/lonestar/eda/cpu/SPRoute/maze_finegrain.h
+++ b/lonestar/eda/cpu/SPRoute/maze_finegrain.h
@@ -12,8 +12,6 @@ void mazeRouteMSMD_finegrain(int iter, int expand, float costHeight,
                              int ripup_threshold, int mazeedge_Threshold,
                              Bool Ordering, int cost_type,
                              galois::InsertBag<int>* net_shuffle)
-// galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>*
-// thread_local_storage)
 {
   // LOCK = 0;
   galois::StatTimer timer_finegrain("fine grain function", "fine grain maze");
@@ -94,7 +92,7 @@ void mazeRouteMSMD_finegrain(int iter, int expand, float costHeight,
     // printf("order?\n");
   }
 
-  THREAD_LOCAL_STORAGE* thread_local_storage = new THREAD_LOCAL_STORAGE;
+  THREAD_LOCAL_STORAGE thread_local_storage{};
   // for(nidRPC=0; nidRPC<numValidNets; nidRPC++)//parallelize
   PerThread_PQ perthread_pq;
   PerThread_Vec perthread_vec;
@@ -142,23 +140,23 @@ void mazeRouteMSMD_finegrain(int iter, int expand, float costHeight,
     TreeEdge *treeedges, *treeedge;
     TreeNode* treenodes;
 
-    bool* pop_heap2 = thread_local_storage->pop_heap2;
+    bool* pop_heap2 = thread_local_storage.pop_heap2;
 
-    float** d1    = thread_local_storage->d1_p;
-    bool** HV     = thread_local_storage->HV_p;
-    bool** hyperV = thread_local_storage->hyperV_p;
-    bool** hyperH = thread_local_storage->hyperH_p;
+    float** d1    = thread_local_storage.d1_p;
+    bool** HV     = thread_local_storage.HV_p;
+    bool** hyperV = thread_local_storage.hyperV_p;
+    bool** hyperH = thread_local_storage.hyperH_p;
 
-    short** parentX1 = thread_local_storage->parentX1_p;
-    short** parentX3 = thread_local_storage->parentX3_p;
-    short** parentY1 = thread_local_storage->parentY1_p;
-    short** parentY3 = thread_local_storage->parentY3_p;
+    short** parentX1 = thread_local_storage.parentX1_p;
+    short** parentX3 = thread_local_storage.parentX3_p;
+    short** parentY1 = thread_local_storage.parentY1_p;
+    short** parentY3 = thread_local_storage.parentY3_p;
 
-    int** corrEdge = thread_local_storage->corrEdge_p;
+    int** corrEdge = thread_local_storage.corrEdge_p;
 
-    OrderNetEdge* netEO = thread_local_storage->netEO_p;
+    OrderNetEdge* netEO = thread_local_storage.netEO_p;
 
-    bool** inRegion = thread_local_storage->inRegion_p;
+    bool** inRegion = thread_local_storage.inRegion_p;
 
     local_pq pq1 = perthread_pq.get();
     local_vec v2 = perthread_vec.get();
@@ -1009,9 +1007,6 @@ void mazeRouteMSMD_finegrain(int iter, int expand, float costHeight,
   //}, "mazeroute vtune function");
   free(h_costTable);
   free(v_costTable);
-
-  // thread_local_storage->clear();
-  delete thread_local_storage;
 }
 
 void mazeRouteMSMD_finegrain_spinlock(int iter, int expand, float costHeight,
@@ -1090,7 +1085,7 @@ void mazeRouteMSMD_finegrain_spinlock(int iter, int expand, float costHeight,
     // printf("order?\n");
   }
 
-  THREAD_LOCAL_STORAGE* thread_local_storage = new THREAD_LOCAL_STORAGE;
+  THREAD_LOCAL_STORAGE thread_local_storage{};
   // for(nidRPC=0; nidRPC<numValidNets; nidRPC++)//parallelize
   PerThread_PQ perthread_pq;
   PerThread_Vec perthread_vec;
@@ -1144,23 +1139,23 @@ void mazeRouteMSMD_finegrain_spinlock(int iter, int expand, float costHeight,
     TreeEdge *treeedges, *treeedge;
     TreeNode* treenodes;
 
-    bool* pop_heap2 = thread_local_storage->pop_heap2;
+    bool* pop_heap2 = thread_local_storage.pop_heap2;
 
-    float** d1    = thread_local_storage->d1_p;
-    bool** HV     = thread_local_storage->HV_p;
-    bool** hyperV = thread_local_storage->hyperV_p;
-    bool** hyperH = thread_local_storage->hyperH_p;
+    float** d1    = thread_local_storage.d1_p;
+    bool** HV     = thread_local_storage.HV_p;
+    bool** hyperV = thread_local_storage.hyperV_p;
+    bool** hyperH = thread_local_storage.hyperH_p;
 
-    short** parentX1 = thread_local_storage->parentX1_p;
-    short** parentX3 = thread_local_storage->parentX3_p;
-    short** parentY1 = thread_local_storage->parentY1_p;
-    short** parentY3 = thread_local_storage->parentY3_p;
+    short** parentX1 = thread_local_storage.parentX1_p;
+    short** parentX3 = thread_local_storage.parentX3_p;
+    short** parentY1 = thread_local_storage.parentY1_p;
+    short** parentY3 = thread_local_storage.parentY3_p;
 
-    int** corrEdge = thread_local_storage->corrEdge_p;
+    int** corrEdge = thread_local_storage.corrEdge_p;
 
-    OrderNetEdge* netEO = thread_local_storage->netEO_p;
+    OrderNetEdge* netEO = thread_local_storage.netEO_p;
 
-    bool** inRegion = thread_local_storage->inRegion_p;
+    bool** inRegion = thread_local_storage.inRegion_p;
 
     local_pq pq1 = perthread_pq.get();
     local_vec v2 = perthread_vec.get();
@@ -1981,9 +1976,6 @@ void mazeRouteMSMD_finegrain_spinlock(int iter, int expand, float costHeight,
   }
   free(h_costTable);
   free(v_costTable);
-
-  thread_local_storage->clear();
-  delete thread_local_storage;
 }
 
 void mazeRouteMSMD_finegrain_doall(int iter, int expand, float costHeight,
@@ -2057,7 +2049,7 @@ void mazeRouteMSMD_finegrain_doall(int iter, int expand, float costHeight,
     // printf("order?\n");
   }
 
-  THREAD_LOCAL_STORAGE* thread_local_storage = new THREAD_LOCAL_STORAGE;
+  THREAD_LOCAL_STORAGE thread_local_storage{};
   // for(nidRPC=0; nidRPC<numValidNets; nidRPC++)//parallelize
   PerThread_PQ perthread_pq;
   PerThread_Vec perthread_vec;
@@ -2097,23 +2089,23 @@ void mazeRouteMSMD_finegrain_doall(int iter, int expand, float costHeight,
     TreeEdge *treeedges, *treeedge;
     TreeNode* treenodes;
 
-    bool* pop_heap2 = thread_local_storage->pop_heap2;
+    bool* pop_heap2 = thread_local_storage.pop_heap2;
 
-    float** d1    = thread_local_storage->d1_p;
-    bool** HV     = thread_local_storage->HV_p;
-    bool** hyperV = thread_local_storage->hyperV_p;
-    bool** hyperH = thread_local_storage->hyperH_p;
+    float** d1    = thread_local_storage.d1_p;
+    bool** HV     = thread_local_storage.HV_p;
+    bool** hyperV = thread_local_storage.hyperV_p;
+    bool** hyperH = thread_local_storage.hyperH_p;
 
-    short** parentX1 = thread_local_storage->parentX1_p;
-    short** parentX3 = thread_local_storage->parentX3_p;
-    short** parentY1 = thread_local_storage->parentY1_p;
-    short** parentY3 = thread_local_storage->parentY3_p;
+    short** parentX1 = thread_local_storage.parentX1_p;
+    short** parentX3 = thread_local_storage.parentX3_p;
+    short** parentY1 = thread_local_storage.parentY1_p;
+    short** parentY3 = thread_local_storage.parentY3_p;
 
-    int** corrEdge = thread_local_storage->corrEdge_p;
+    int** corrEdge = thread_local_storage.corrEdge_p;
 
-    OrderNetEdge* netEO = thread_local_storage->netEO_p;
+    OrderNetEdge* netEO = thread_local_storage.netEO_p;
 
-    bool** inRegion = thread_local_storage->inRegion_p;
+    bool** inRegion = thread_local_storage.inRegion_p;
 
     local_pq pq1 = perthread_pq.get();
     local_vec v2 = perthread_vec.get();
@@ -3050,7 +3042,4 @@ void mazeRouteMSMD_finegrain_doall(int iter, int expand, float costHeight,
   //}, "mazeroute vtune function");
   free(h_costTable);
   free(v_costTable);
-
-  thread_local_storage->clear();
-  delete thread_local_storage;
 }

--- a/lonestar/eda/cpu/SPRoute/maze_lock.h
+++ b/lonestar/eda/cpu/SPRoute/maze_lock.h
@@ -117,8 +117,6 @@ void mazeRouteMSMD_lock(int iter, int expand, float costHeight,
                         int ripup_threshold, int mazeedge_Threshold,
                         Bool Ordering, int cost_type,
                         galois::InsertBag<int>* net_shuffle)
-// galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>*
-// thread_local_storage)
 {
   // LOCK = 0;
   float forange;
@@ -183,9 +181,8 @@ void mazeRouteMSMD_lock(int iter, int expand, float costHeight,
     // printf("order?\n");
   }
 
-  galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>*
-      thread_local_storage =
-          new galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>;
+  galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>
+      thread_local_storage{};
   // for(nidRPC=0; nidRPC<numValidNets; nidRPC++)//parallelize
   PerThread_PQ perthread_pq;
   PerThread_Vec perthread_vec;
@@ -229,23 +226,23 @@ void mazeRouteMSMD_lock(int iter, int expand, float costHeight,
         TreeEdge *treeedges, *treeedge;
         TreeNode* treenodes;
 
-        bool* pop_heap2 = thread_local_storage->getLocal()->pop_heap2;
+        bool* pop_heap2 = thread_local_storage.getLocal()->pop_heap2;
 
-        float** d1    = thread_local_storage->getLocal()->d1_p;
-        bool** HV     = thread_local_storage->getLocal()->HV_p;
-        bool** hyperV = thread_local_storage->getLocal()->hyperV_p;
-        bool** hyperH = thread_local_storage->getLocal()->hyperH_p;
+        float** d1    = thread_local_storage.getLocal()->d1_p;
+        bool** HV     = thread_local_storage.getLocal()->HV_p;
+        bool** hyperV = thread_local_storage.getLocal()->hyperV_p;
+        bool** hyperH = thread_local_storage.getLocal()->hyperH_p;
 
-        short** parentX1 = thread_local_storage->getLocal()->parentX1_p;
-        short** parentX3 = thread_local_storage->getLocal()->parentX3_p;
-        short** parentY1 = thread_local_storage->getLocal()->parentY1_p;
-        short** parentY3 = thread_local_storage->getLocal()->parentY3_p;
+        short** parentX1 = thread_local_storage.getLocal()->parentX1_p;
+        short** parentX3 = thread_local_storage.getLocal()->parentX3_p;
+        short** parentY1 = thread_local_storage.getLocal()->parentY1_p;
+        short** parentY3 = thread_local_storage.getLocal()->parentY3_p;
 
-        int** corrEdge = thread_local_storage->getLocal()->corrEdge_p;
+        int** corrEdge = thread_local_storage.getLocal()->corrEdge_p;
 
-        OrderNetEdge* netEO = thread_local_storage->getLocal()->netEO_p;
+        OrderNetEdge* netEO = thread_local_storage.getLocal()->netEO_p;
 
-        bool** inRegion = thread_local_storage->getLocal()->inRegion_p;
+        bool** inRegion = thread_local_storage.getLocal()->inRegion_p;
         // bool* inRegion_alloc =
         // thread_local_storage->getLocal()->inRegion_alloc;
 
@@ -997,19 +994,12 @@ void mazeRouteMSMD_lock(int iter, int expand, float costHeight,
   free(h_costTable);
   free(v_costTable);
 
-  galois::on_each([&](const unsigned tid, const unsigned numT) {
-    thread_local_storage->getLocal()->clear();
-  });
-
-  // free memory
 }
 
 void mazeRouteMSMD_M1M2(int iter, int expand, float costHeight,
                         int ripup_threshold, int mazeedge_Threshold,
                         Bool Ordering, int cost_type,
                         galois::InsertBag<int>* net_shuffle)
-// galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>*
-// thread_local_storage)
 {
   // LOCK = 0;
   float forange;
@@ -1074,9 +1064,8 @@ void mazeRouteMSMD_M1M2(int iter, int expand, float costHeight,
     // printf("order?\n");
   }
 
-  galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>*
-      thread_local_storage =
-          new galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>;
+  galois::substrate::PerThreadStorage<THREAD_LOCAL_STORAGE>
+      thread_local_storage{};
   // for(nidRPC=0; nidRPC<numValidNets; nidRPC++)//parallelize
   PerThread_PQ perthread_pq;
   PerThread_Vec perthread_vec;
@@ -1119,25 +1108,25 @@ void mazeRouteMSMD_M1M2(int iter, int expand, float costHeight,
         TreeEdge *treeedges, *treeedge;
         TreeNode* treenodes;
 
-        bool* pop_heap2 = thread_local_storage->getLocal()->pop_heap2;
+        bool* pop_heap2 = thread_local_storage.getLocal()->pop_heap2;
 
-        float** d1    = thread_local_storage->getLocal()->d1_p;
-        bool** HV     = thread_local_storage->getLocal()->HV_p;
-        bool** hyperV = thread_local_storage->getLocal()->hyperV_p;
-        bool** hyperH = thread_local_storage->getLocal()->hyperH_p;
+        float** d1    = thread_local_storage.getLocal()->d1_p;
+        bool** HV     = thread_local_storage.getLocal()->HV_p;
+        bool** hyperV = thread_local_storage.getLocal()->hyperV_p;
+        bool** hyperH = thread_local_storage.getLocal()->hyperH_p;
 
-        short** parentX1 = thread_local_storage->getLocal()->parentX1_p;
-        short** parentX3 = thread_local_storage->getLocal()->parentX3_p;
-        short** parentY1 = thread_local_storage->getLocal()->parentY1_p;
-        short** parentY3 = thread_local_storage->getLocal()->parentY3_p;
+        short** parentX1 = thread_local_storage.getLocal()->parentX1_p;
+        short** parentX3 = thread_local_storage.getLocal()->parentX3_p;
+        short** parentY1 = thread_local_storage.getLocal()->parentY1_p;
+        short** parentY3 = thread_local_storage.getLocal()->parentY3_p;
 
-        int** corrEdge = thread_local_storage->getLocal()->corrEdge_p;
+        int** corrEdge = thread_local_storage.getLocal()->corrEdge_p;
 
-        OrderNetEdge* netEO = thread_local_storage->getLocal()->netEO_p;
+        OrderNetEdge* netEO = thread_local_storage.getLocal()->netEO_p;
 
-        bool** inRegion = thread_local_storage->getLocal()->inRegion_p;
+        bool** inRegion = thread_local_storage.getLocal()->inRegion_p;
         // bool* inRegion_alloc =
-        // thread_local_storage->getLocal()->inRegion_alloc;
+        // thread_local_storage.getLocal()->inRegion_alloc;
 
         local_pq pq1 = perthread_pq.get();
         local_vec v2 = perthread_vec.get();
@@ -1928,10 +1917,4 @@ void mazeRouteMSMD_M1M2(int iter, int expand, float costHeight,
   //}, "mazeroute vtune function");
   free(h_costTable);
   free(v_costTable);
-
-  galois::on_each([&](const unsigned tid, const unsigned numT) {
-    thread_local_storage->getLocal()->clear();
-  });
-
-  // free memory
 }

--- a/lonestar/eda/cpu/SPRoute/utility.h
+++ b/lonestar/eda/cpu/SPRoute/utility.h
@@ -1207,7 +1207,7 @@ void StNetOrder() {
 
       gridsX = treeedge->route.gridsX;
       gridsY = treeedge->route.gridsY;
-      for (i = 0; i <= treeedge->route.routelen; i++) {
+      for (i = 0; i < treeedge->route.routelen; i++) {
         if (gridsX[i] == gridsX[i + 1]) // a vertical edge
         {
           min_y = min(gridsY[i], gridsY[i + 1]);


### PR DESCRIPTION
This clears out several (but not all) of the memory leaks found by the address sanitizer. I'm disabling the corresponding test in CI again until we get this to pass with the sanitizers.