### PR TITLE
Parse cpuset from /proc/self/status

### DIFF
--- a/libgalois/CMakeLists.txt
+++ b/libgalois/CMakeLists.txt
@@ -7,45 +7,46 @@ configure_file(src/Version.cpp.in Version.cpp @ONLY)
 configure_file(include/galois/config.h.in include/galois/config.h)
 
 set(sources
-        src/SharedMemSys.cpp
-        src/Context.cpp
-        src/PreAlloc.cpp
-        src/Support.cpp
-        src/Threads.cpp
-        src/Timer.cpp
-        src/Mem.cpp
-        src/PagePool.cpp
-        src/Deterministic.cpp
-        src/Substrate.cpp
         "${CMAKE_CURRENT_BINARY_DIR}/Version.cpp"
-        src/PagePool.cpp
-        src/Statistics.cpp
-        src/Barrier.cpp
         src/Barrier_Counting.cpp
+        src/Barrier.cpp
         src/Barrier_Dissemination.cpp 
         src/Barrier_MCS.cpp
-        src/Barrier_Topo.cpp 
         src/Barrier_Pthread.cpp
         src/Barrier_Simple.cpp
-        src/gIO.cpp
-        src/ThreadPool.cpp
-        src/SimpleLock.cpp
-        src/PtrLock.cpp
-        src/Profile.cpp
+        src/Barrier_Topo.cpp
+        src/Context.cpp
+        src/Deterministic.cpp
+        src/DynamicBitset.cpp
         src/EnvCheck.cpp
-        src/PerThreadStorage.cpp
-        src/Termination.cpp
-        src/NumaMem.cpp
-        src/PageAlloc.cpp
-        src/SharedMem.cpp
         src/FileGraph.cpp
         src/FileGraphParallel.cpp
-        src/OCFileGraph.cpp
+        src/gIO.cpp
         src/GraphHelpers.cpp
+        src/HWTopo.cpp
+        src/Mem.cpp
+        src/NumaMem.cpp
+        src/OCFileGraph.cpp
+        src/PageAlloc.cpp
+        src/PagePool.cpp
+        src/PagePool.cpp
         src/ParaMeter.cpp
-        src/DynamicBitset.cpp
-        src/Tracer.cpp
+        src/PerThreadStorage.cpp
+        src/PreAlloc.cpp
+        src/Profile.cpp
+        src/PtrLock.cpp
+        src/SharedMem.cpp
+        src/SharedMemSys.cpp
+        src/SimpleLock.cpp
+        src/Statistics.cpp
+        src/Substrate.cpp
+        src/Support.cpp
+        src/Termination.cpp
+        src/ThreadPool.cpp
+        src/Threads.cpp
         src/ThreadTimer.cpp
+        src/Timer.cpp
+        src/Tracer.cpp
 )
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/libgalois/include/galois/substrate/HWTopo.h
+++ b/libgalois/include/galois/substrate/HWTopo.h
@@ -20,14 +20,14 @@
 #ifndef GALOIS_SUBSTRATE_HWTOPO_H
 #define GALOIS_SUBSTRATE_HWTOPO_H
 
+#include <string>
 #include <vector>
 
 #include "galois/config.h"
 
-namespace galois {
-namespace substrate {
+namespace galois::substrate {
 
-struct threadTopoInfo {
+struct ThreadTopoInfo {
   unsigned tid;                 // this thread (galois id)
   unsigned socketLeader;        // first thread id in tid's socket
   unsigned socket;              // socket (L3 normally) of thread
@@ -37,19 +37,35 @@ struct threadTopoInfo {
   unsigned osNumaNode;          // OS ID for numa node
 };
 
-struct machineTopoInfo {
+struct MachineTopoInfo {
   unsigned maxThreads;
   unsigned maxCores;
   unsigned maxSockets;
   unsigned maxNumaNodes;
 };
 
-// parse machine topology
-std::pair<machineTopoInfo, std::vector<threadTopoInfo>> getHWTopo();
-// bind a thread to a hwContext (returned by getHWTopo)
+struct HWTopoInfo {
+  MachineTopoInfo machineTopoInfo;
+  std::vector<ThreadTopoInfo> threadTopoInfo;
+};
+
+/**
+ * getHWTopo determines the machine topology from the process information
+ * exposed in /proc and /dev filesystems.
+ */
+HWTopoInfo getHWTopo();
+
+/**
+ * parseCPUList parses cpuset information in "List format" as described in
+ * cpuset(7) and available under /proc/self/status
+ */
+std::vector<int> parseCPUList(const std::string& in);
+
+/**
+ * bindThreadSelf binds a thread to an osContext as returned by getHWTopo.
+ */
 bool bindThreadSelf(unsigned osContext);
 
-} // end namespace substrate
-} // end namespace galois
+} // namespace galois::substrate
 
-#endif //_HWTOPO_H
+#endif

--- a/libgalois/include/galois/substrate/ThreadPool.h
+++ b/libgalois/include/galois/substrate/ThreadPool.h
@@ -69,7 +69,7 @@ protected:
     unsigned wbegin, wend;
     std::atomic<int> done;
     std::atomic<int> fastRelease;
-    threadTopoInfo topo;
+    ThreadTopoInfo topo;
 
     void wakeup(bool fastmode) {
       if (fastmode) {
@@ -99,7 +99,7 @@ protected:
 
   thread_local static per_signal my_box;
 
-  machineTopoInfo mi;
+  MachineTopoInfo mi;
   std::vector<per_signal*> signals;
   std::vector<std::thread> threads;
   unsigned reserved;

--- a/libgalois/src/HWTopo.cpp
+++ b/libgalois/src/HWTopo.cpp
@@ -1,0 +1,37 @@
+#include "galois/substrate/HWTopo.h"
+
+#include <stdexcept>
+
+std::vector<int> galois::substrate::parseCPUList(const std::string& line) {
+  std::vector<int> vals;
+
+  size_t current;
+  size_t next = -1;
+  try {
+    do {
+      current  = next + 1;
+      next     = line.find_first_of(',', current);
+      auto buf = line.substr(current, next - current);
+      if (!buf.empty()) {
+        size_t dash = buf.find_first_of('-', 0);
+        if (dash != std::string::npos) { // range
+          auto first  = buf.substr(0, dash);
+          auto second = buf.substr(dash + 1, std::string::npos);
+          unsigned b  = std::stoi(first.data());
+          unsigned e  = std::stoi(second.data());
+          while (b <= e) {
+            vals.push_back(b++);
+          }
+        } else { // singleton
+          vals.push_back(std::stoi(buf.data()));
+        }
+      }
+    } while (next != std::string::npos);
+  } catch (const std::invalid_argument&) {
+    return std::vector<int>{};
+  } catch (const std::out_of_range&) {
+    return std::vector<int>{};
+  }
+
+  return vals;
+}

--- a/libgalois/src/ThreadPool.cpp
+++ b/libgalois/src/ThreadPool.cpp
@@ -38,7 +38,7 @@ using galois::substrate::ThreadPool;
 thread_local ThreadPool::per_signal ThreadPool::my_box;
 
 ThreadPool::ThreadPool()
-    : mi(getHWTopo().first), reserved(0), masterFastmode(false),
+    : mi(getHWTopo().machineTopoInfo), reserved(0), masterFastmode(false),
       running(false) {
   signals.resize(mi.maxThreads);
   initThread(0);
@@ -117,7 +117,7 @@ static T* getNth(std::atomic<T*>& headptr, unsigned off) {
 
 void ThreadPool::initThread(unsigned tid) {
   signals[tid] = &my_box;
-  my_box.topo  = getHWTopo().second[tid];
+  my_box.topo  = getHWTopo().threadTopoInfo[tid];
   // Initialize
   substrate::initPTS(mi.maxThreads);
 

--- a/libgalois/test/hwtopo.cpp
+++ b/libgalois/test/hwtopo.cpp
@@ -18,20 +18,60 @@
  */
 
 #include "galois/substrate/HWTopo.h"
+#include "galois/gIO.h"
 
 #include <iostream>
 
-int main() {
+void printMyTopo() {
   auto t = galois::substrate::getHWTopo();
-  std::cout << "T,C,P,N: " << t.first.maxThreads << " " << t.first.maxCores
-            << " " << t.first.maxSockets << " " << t.first.maxNumaNodes << "\n";
-  for (unsigned i = 0; i < t.first.maxThreads; ++i) {
-    auto& c = t.second[i];
+  std::cout << "T,C,P,N: " << t.machineTopoInfo.maxThreads << " "
+            << t.machineTopoInfo.maxCores << " " << t.machineTopoInfo.maxSockets
+            << " " << t.machineTopoInfo.maxNumaNodes << "\n";
+  for (unsigned i = 0; i < t.machineTopoInfo.maxThreads; ++i) {
+    auto& c = t.threadTopoInfo[i];
     std::cout << "tid: " << c.tid << " leader: " << c.socketLeader
               << " socket: " << c.socket << " numaNode: " << c.numaNode
               << " cumulativeMaxSocket: " << c.cumulativeMaxSocket
               << " osContext: " << c.osContext
               << " osNumaNode: " << c.osNumaNode << "\n";
   }
+}
+
+void test(const std::string& name, const std::vector<int>& found,
+          const std::vector<int>& expected) {
+  if (found != expected) {
+    std::cerr << "test " << name << " failed\n";
+
+    std::cerr << "found: ";
+    for (auto i : found) {
+      std::cerr << i;
+    }
+    std::cerr << "\n";
+
+    std::cerr << "expected: ";
+    for (auto i : expected) {
+      std::cerr << i;
+    }
+    std::cerr << "\n";
+    std::abort();
+  }
+}
+
+int main() {
+  printMyTopo();
+
+  using namespace galois::substrate;
+
+  test("parse with spaces", parseCPUList("     0   \n"), std::vector<int>{0});
+  test("parse empty", parseCPUList("        \n"), std::vector<int>{});
+  test("parse singletons", parseCPUList("     0,1,2   \n"),
+       std::vector<int>{0, 1, 2});
+  test("parse mix of singletons and ranges", parseCPUList("     0,1,2-4   \n"),
+       std::vector<int>{0, 1, 2, 3, 4});
+  test("parse multiple ranges", parseCPUList("     0-1,2-4   \n"),
+       std::vector<int>{0, 1, 2, 3, 4});
+  test("parse range", parseCPUList("     0-4   \n"),
+       std::vector<int>{0, 1, 2, 3, 4});
+
   return 0;
 }


### PR DESCRIPTION
/dev/cpuset may not be mounted in all the environments we run in. In
particular, Docker containers do not mount it. Instead, we can derive
cpuset information from /proc/self/status which always contains the
cpuset information for the current process.

Along the way fix a potential issue where invalid cpuset configurations
would be interpreted as std::vector<int>{0} rather than
std::vector<int>{} due to atoi returning 0 for invalid inputs.

Closes #192 