### PR TITLE
Remove machine dependence in barrier unit test

### DIFF
--- a/libgalois/test/CMakeLists.txt
+++ b/libgalois/test/CMakeLists.txt
@@ -32,7 +32,7 @@ endfunction()
 
 add_test_unit(acquire)
 add_test_unit(bandwidth)
-add_test_unit(barriers)
+add_test_unit(barriers 1024 2)
 add_test_unit(empty-member-lcgraph)
 add_test_unit(flatmap)
 add_test_unit(floatingPointErrors)


### PR DESCRIPTION
Without arguments, unit-barriers tests up to the number of threads on
the host machine. This reduces the reproducibility of our test suite.
Instead, set the number of threads to use to a smaller, more modest
number.

Closes #198 