### PR TITLE
Allow Locally Disabling -Werror

### DIFF
--- a/libgalois/include/galois/config.h.in
+++ b/libgalois/include/galois/config.h.in
@@ -19,6 +19,17 @@ _Pragma("GCC diagnostic warning \"-Wextra\"")
 #define GALOIS_END_ALLOW_WARNINGS
 #endif
 
+#if defined(__GNUC__)
+#define GALOIS_IGNORE_WARNINGS               \
+_Pragma("GCC diagnostic push")               \
+_Pragma("GCC diagnostic ignored \"-Wall\"")  \
+_Pragma("GCC diagnostic ignored \"-Wextra\"")
+#define GALOIS_END_IGNORE_WARNINGS _Pragma("GCC diagnostic pop")
+#else
+#define GALOIS_IGNORE_WARNINGS
+#define GALOIS_END_IGNORE_WARNINGS
+#endif
+
 // Macro to suppress compiler warnings that a variable is set but unused.
 // This warning is buggy in gcc 7.
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8

--- a/libgalois/include/galois/config.h.in
+++ b/libgalois/include/galois/config.h.in
@@ -8,6 +8,17 @@
 #error Exactly one of GALOIS_USE_LONGJMP_ABORT or GALOIS_USE_EXCEPTION_ABORT must be defined.
 #endif
 
+#if defined(__GNUC__)
+#define GALOIS_ALLOW_WARNINGS                \
+_Pragma("GCC diagnostic push")               \
+_Pragma("GCC diagnostic warning \"-Wall\"")  \
+_Pragma("GCC diagnostic warning \"-Wextra\"")
+#define GALOIS_END_ALLOW_WARNINGS _Pragma("GCC diagnostic pop")
+#else
+#define GALOIS_ALLOW_WARNINGS
+#define GALOIS_END_ALLOW_WARNINGS
+#endif
+
 // Macro to suppress compiler warnings that a variable is set but unused.
 // This warning is buggy in gcc 7.
 #if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 8


### PR DESCRIPTION
This adds macros that can be used to turn off `-Werror` for including external headers. Here's a usage example:

```
GALOIS_ALLOW_WARNINGS
#include "external_header_causing_warnings.hpp"
GALOIS_END_ALLOW_WARNINGS
```
