### PR TITLE
Parallel relabelling for triangle counting

### DIFF
--- a/libgalois/include/galois/ParallelSTL.h
+++ b/libgalois/include/galois/ParallelSTL.h
@@ -27,6 +27,7 @@
 #include "galois/Reduction.h"
 #include "galois/Traits.h"
 #include "galois/UserContext.h"
+#include "galois/Threads.h"
 #include "galois/worklists/Chunk.h"
 
 namespace galois {
@@ -315,9 +316,10 @@ OutputIt partial_sum(InputIt first, InputIt last, OutputIt d_first) {
 
   size_t sizeOfVector = std::distance(first, last);
 
-  const size_t blockSize = 1 << 20;
   // optimization possible here: if num blocks = 1, then no need for 2 passes
-  const size_t numBlocks = (sizeOfVector + blockSize - 1) / blockSize;
+  const size_t numBlocks = galois::getActiveThreads();
+  const size_t blockSize = (sizeOfVector + numBlocks - 1) / numBlocks;
+  assert(numBlocks * blockSize >= sizeOfVector);
 
   std::vector<ValueType> localSums(numBlocks);
 

--- a/libgalois/include/galois/graphs/LC_CSR_Graph.h
+++ b/libgalois/include/galois/graphs/LC_CSR_Graph.h
@@ -862,16 +862,7 @@ public:
       }
     });
 
-    galois::on_each([&](unsigned tid, unsigned total) {
-      std::vector<unsigned>
-          dummy_scale_factor; // dummy passed in to function call
-
-      auto r = divideByNode(0, 1, tid, total).first;
-
-      // galois::gPrint("[", tid, "] : Ranges : ", *r.first, ", ", *r.second,
-      // "\n");
-      this->setLocalRange(*r.first, *r.second);
-    });
+    initializeLocalRanges();
   }
   void constructFrom(
       uint32_t numNodes, uint64_t numEdges, std::vector<uint64_t>& prefix_sum,
@@ -900,16 +891,7 @@ public:
       }
     });
 
-    galois::on_each([&](unsigned tid, unsigned total) {
-      std::vector<unsigned>
-          dummy_scale_factor; // dummy passed in to function call
-
-      auto r = divideByNode(0, 1, tid, total).first;
-
-      // galois::gPrint("[", tid, "] : Ranges : ", *r.first, ", ", *r.second,
-      // "\n");
-      this->setLocalRange(*r.first, *r.second);
-    });
+    initializeLocalRanges();
   }
 
   /**
@@ -989,12 +971,8 @@ public:
     graphFile.seekg(readPosition);
     graphFile.read(reinterpret_cast<char*>(edgeData.data()),
                    sizeof(EdgeTy) * numEdges);
-    galois::on_each([&](unsigned tid, unsigned total) {
-      std::vector<unsigned>
-          dummy_scale_factor; // dummy passed in to function call
-      auto r = divideByNode(0, 1, tid, total).first;
-      this->setLocalRange(*r.first, *r.second);
-    });
+
+    initializeLocalRanges();
     graphFile.close();
   }
 
@@ -1052,14 +1030,22 @@ public:
     } else {
       GALOIS_DIE("ERROR: Unknown graph file version.");
     }
+
+    initializeLocalRanges();
+    graphFile.close();
+  }
+
+  /**
+   * Given a manually created graph, initialize the local ranges on this graph
+   * so that threads can iterate over a balanced number of vertices.
+   */
+  void initializeLocalRanges() {
     galois::on_each([&](unsigned tid, unsigned total) {
       std::vector<unsigned>
           dummy_scale_factor; // dummy passed in to function call
       auto r = divideByNode(0, 1, tid, total).first;
       this->setLocalRange(*r.first, *r.second);
     });
-
-    graphFile.close();
   }
 };
 } // namespace graphs


### PR DESCRIPTION
Changed the sorting routine used by triangle counting to be more efficient. Before, it was basically single threaded: more parallelism has been introduced into the procedure.

One thing that may help further is if std::sort parallelism is enabled (if it isn't). GAP is very likely doing so as it enables OpenMP.

https://stackoverflow.com/questions/28520720/c-parallel-sort

This also includes a change to LC_CSR_Graph to expose the local range initialization to allow threads to iterate over a more balanced workload (and required if you want to directly call galois::iterate on an LC_CSR_Graph object).