### PR TITLE
Structured output

### DIFF
--- a/lonestar/analytics/distributed/README.md
+++ b/lonestar/analytics/distributed/README.md
@@ -99,11 +99,11 @@ Number of threads to use on a single machine excluding a communication thread
 that is used by all of the provided distributed benchmarks. Note that 
 GPUs only use 1 thread (excluding the communication thread).
 
-`-verify`
+`-output` / `-outputLocation=<directory>`
 
-Outputs a file with the result of running the application. For example, 
-specifying this flag on a bfs application will output the shortest distances
-to each node.
+Outputs the result of running the application to a file. For example,
+specifying this flag on a bfs application will output the shortest distances to
+each node.
 
 Running Provided Apps (Distributed Heterogeneous Apps)
 ================================================================================

--- a/lonestar/analytics/distributed/bc/bc_level.cpp
+++ b/lonestar/analytics/distributed/bc/bc_level.cpp
@@ -24,16 +24,16 @@
 
 //#define BCDEBUG
 
-constexpr static const char* const REGION_NAME = "BC";
-
-#include <iomanip>
-#include <iostream>
-#include <limits>
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/runtime/Tracer.h"
+
+#include <iomanip>
+#include <iostream>
+#include <limits>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "bc_level_cuda.h"
@@ -44,6 +44,8 @@ using ShortPathType = double;
 enum { CPU, GPU_CUDA };
 int personality = CPU;
 #endif
+
+constexpr static const char* const REGION_NAME = "BC";
 
 /******************************************************************************/
 /* Declaration of command line arguments */
@@ -117,6 +119,7 @@ galois::graphs::GluonSubstrate<Graph>* syncSubstrate;
 /******************************************************************************/
 /* Functors for running the algorithm */
 /******************************************************************************/
+
 struct InitializeGraph {
   Graph* graph;
 
@@ -576,6 +579,47 @@ struct Sanity {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<float> makeResultsCPU(Graph* hg) {
+  std::vector<float> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).betweeness_centrality);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<float> makeResultsGPU(Graph* hg) {
+  std::vector<float> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_betweeness_centrality_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<float> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<float> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main method for running */
 /******************************************************************************/
 
@@ -583,7 +627,7 @@ constexpr static const char* const name =
     "Betweeness Centrality Level by Level";
 constexpr static const char* const desc =
     "Betweeness Centrality Level by Level on Distributed Galois.";
-constexpr static const char* const url = 0;
+constexpr static const char* const url = nullptr;
 
 int main(int argc, char** argv) {
   galois::DistMemSys G;
@@ -603,7 +647,7 @@ int main(int argc, char** argv) {
   std::tie(h_graph, syncSubstrate) = distGraphInitialization<NodeData, void>();
 #endif
 
-  if (sourcesToUse != "") {
+  if (!sourcesToUse.empty()) {
     sourceFile.open(sourcesToUse);
     std::vector<uint64_t> t(std::istream_iterator<uint64_t>{sourceFile},
                             std::istream_iterator<uint64_t>{});
@@ -646,7 +690,7 @@ int main(int argc, char** argv) {
       }
 
       // if provided a file of sources to work with, use that
-      if (sourceVector.size() != 0) {
+      if (!sourceVector.empty()) {
         if (loop_end > sourceVector.size()) {
           loop_end = sourceVector.size();
         }
@@ -721,36 +765,18 @@ int main(int argc, char** argv) {
         bitset_dependency.reset();
       }
 
-      InitializeGraph::go((*h_graph));
+      InitializeGraph::go(*h_graph);
       galois::runtime::getHostBarrier().wait();
     }
   }
 
   StatTimer_total.stop();
 
-  // Verify, i.e. print out graph data for examination
-  if (verify) {
-    if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*h_graph).masterNodesRange().begin();
-           ii != (*h_graph).masterNodesRange().end(); ++ii) {
-        std::stringstream out;
-        out << (*h_graph).getGID(*ii) << " " << std::setprecision(9)
-            << get_node_betweeness_centrality_cuda(cuda_ctx, *ii) << "\n";
-        galois::runtime::printOutput(out.str().c_str());
-      }
-#else
-      abort();
-#endif
-    } else if (personality == CPU) {
-      for (auto ii = (*h_graph).masterNodesRange().begin();
-           ii != (*h_graph).masterNodesRange().end(); ++ii) {
-        std::stringstream out;
-        out << (*h_graph).getGID(*ii) << " " << std::setprecision(9)
-            << (*h_graph).getData(*ii).betweeness_centrality << "\n";
-        galois::runtime::printOutput(out.str().c_str());
-      }
-    }
+  if (output) {
+    std::vector<float> results = makeResults(h_graph);
+
+    writeOutput(outputLocation, "betweenness_centrality", results.data(),
+                results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/bc/bc_level.cpp
+++ b/lonestar/analytics/distributed/bc/bc_level.cpp
@@ -474,9 +474,7 @@ struct BC {
       // point, add them to the betweeness centrality measure on each node
       if (personality == GPU_CUDA) {
 #ifdef GALOIS_ENABLE_GPU
-        std::string impl_str(
-            // syncSubstrate->get_run_identifier("BC")
-            std::string(REGION_NAME));
+        std::string impl_str("BC");
         galois::StatTimer StatTimer_cuda(impl_str.c_str(), REGION_NAME);
         StatTimer_cuda.start();
         BC_masterNodes_cuda(cuda_ctx);

--- a/lonestar/analytics/distributed/bc/bc_level.cpp
+++ b/lonestar/analytics/distributed/bc/bc_level.cpp
@@ -29,10 +29,9 @@ constexpr static const char* const REGION_NAME = "BC";
 #include <iomanip>
 #include <iostream>
 #include <limits>
-
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/runtime/Tracer.h"
 

--- a/lonestar/analytics/distributed/bc/bc_level.cpp
+++ b/lonestar/analytics/distributed/bc/bc_level.cpp
@@ -59,8 +59,8 @@ static cll::opt<bool>
     singleSourceBC("singleSource",
                    cll::desc("Use for single source BC (default off)"),
                    cll::init(false));
-static cll::opt<unsigned long long>
-    startSource("startNode", // not uint64_t due to a bug in llvm cl
+static cll::opt<uint64_t>
+    startSource("startNode",
                 cll::desc("Starting source node used for "
                           "betweeness-centrality (default 0)"),
                 cll::init(0));

--- a/lonestar/analytics/distributed/bc/bc_mr.cpp
+++ b/lonestar/analytics/distributed/bc/bc_mr.cpp
@@ -19,10 +19,10 @@
 
 constexpr static const char* const REGION_NAME = "MRBC";
 
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/DReducible.h"
 #include "galois/runtime/Tracer.h"
-#include "DistBenchStart.h"
 
 #include <iostream>
 #include <iomanip>

--- a/lonestar/analytics/distributed/bc/bc_mr.cpp
+++ b/lonestar/analytics/distributed/bc/bc_mr.cpp
@@ -17,15 +17,14 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-constexpr static const char* const REGION_NAME = "MRBC";
-
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/DReducible.h"
 #include "galois/runtime/Tracer.h"
 
-#include <iostream>
 #include <iomanip>
+#include <iostream>
 
 // type of short path
 using ShortPathType = double;
@@ -38,6 +37,8 @@ struct BCData {
   ShortPathType shortPathCount;
   galois::CopyableAtomic<float> dependencyValue;
 };
+
+constexpr static const char* const REGION_NAME = "MRBC";
 
 /******************************************************************************/
 /* Declaration of command line arguments */
@@ -65,11 +66,6 @@ static cll::opt<unsigned int> vIndex("index",
                                      cll::desc("DEBUG: Index to print for "
                                                "dist/short paths"),
                                      cll::init(0), cll::Hidden);
-// debug vars
-static cll::opt<bool> outputDistPaths("outputDistPaths",
-                                      cll::desc("DEBUG: Output min distance"
-                                                "/short path counts instead"),
-                                      cll::init(false), cll::Hidden);
 static cll::opt<unsigned int>
     vectorSize("vectorSize",
                cll::desc("DEBUG: Specify size of vector "
@@ -524,13 +520,28 @@ void Sanity(Graph& graph) {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<float> makeResults(Graph* hg) {
+  std::vector<float> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).bc);
+  }
+
+  return values;
+}
+
+/******************************************************************************/
 /* Main method for running */
 /******************************************************************************/
 
 constexpr static const char* const name = "Min-Rounds Betweeness Centrality";
 constexpr static const char* const desc = "Min-Rounds Betweeness "
                                           "Centrality on Distributed Galois.";
-constexpr static const char* const url = 0;
+constexpr static const char* const url = nullptr;
 
 uint64_t macroRound = 0; // macro round, i.e. number of batches done so far
 
@@ -582,7 +593,7 @@ int main(int argc, char** argv) {
   // reading in list of sources to operate on if provided
   std::ifstream sourceFile;
   std::vector<uint64_t> sourceVector;
-  if (sourcesToUse != "") {
+  if (!sourcesToUse.empty()) {
     sourceFile.open(sourcesToUse);
     std::vector<uint64_t> t(std::istream_iterator<uint64_t>{sourceFile},
                             std::istream_iterator<uint64_t>{});
@@ -590,7 +601,7 @@ int main(int argc, char** argv) {
     sourceFile.close();
   }
 
-  if (startNode && sourceVector.size()) {
+  if (startNode && !sourceVector.empty()) {
     GALOIS_DIE("Should not use startNode cmd-line option with specified "
                "sources");
   }
@@ -622,7 +633,7 @@ int main(int argc, char** argv) {
     uint64_t offset = startNode;
     // node boundary to end search at
     uint64_t nodeBoundary =
-        sourceVector.size() == 0 ? hg->globalSize() : sourceVector.size();
+        sourceVector.empty() ? hg->globalSize() : sourceVector.size();
 
     while (offset < nodeBoundary && totalSourcesFound < totalNumSources) {
       if (useSingleSource) {
@@ -635,7 +646,7 @@ int main(int argc, char** argv) {
                totalSourcesFound < totalNumSources) {
           // choose from read source file or from beginning (0 to n)
           nodesToConsider[sourcesFound] =
-              sourceVector.size() == 0 ? offset : sourceVector[offset];
+              sourceVector.empty() ? offset : sourceVector[offset];
           offset++;
           sourcesFound++;
           totalSourcesFound++;
@@ -706,8 +717,8 @@ int main(int argc, char** argv) {
     // re-init graph for next run
     if ((run + 1) != numRuns) { // not the last run
       galois::runtime::getHostBarrier().wait();
-      (*syncSubstrate).set_num_run(run + 1);
-      (*syncSubstrate).set_num_round(0);
+      syncSubstrate->set_num_run(run + 1);
+      syncSubstrate->set_num_round(0);
       offset             = 0;
       macroRound         = 0;
       numSourcesPerRound = origNumRoundSources;
@@ -726,27 +737,11 @@ int main(int argc, char** argv) {
 
   ////////////////////////////////////////////////////////////////////////////////
 
-  // Verify, i.e. print out graph data for examination
-  if (verify) {
-    for (auto ii = (*hg).masterNodesRange().begin();
-         ii != (*hg).masterNodesRange().end(); ++ii) {
-      if (!outputDistPaths) {
-        // outputs betweenness centrality
-        std::stringstream out;
-        out << (*hg).getGID(*ii) << " " << std::setprecision(9)
-            << (*hg).getData(*ii).bc << "\n";
-        galois::runtime::printOutput(out.str().c_str());
-      } else {
-        uint64_t a      = 0;
-        ShortPathType b = 0;
-        for (unsigned i = 0; i < numSourcesPerRound; i++) {
-          if ((*hg).getData(*ii).sourceData[i].minDistance != infinity) {
-            a += (*hg).getData(*ii).sourceData[i].minDistance;
-          }
-          b += (*hg).getData(*ii).sourceData[i].shortPathCount;
-        }
-      }
-    }
+  if (output) {
+    std::vector<float> results = makeResults(hg);
+
+    writeOutput(outputLocation, "betweenness_centrality", results.data(),
+                results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/bfs/bfs_pull.cpp
+++ b/lonestar/analytics/distributed/bfs/bfs_pull.cpp
@@ -47,9 +47,8 @@ static cll::opt<unsigned int> maxIterations("maxIterations",
                                                       "Default 1000"),
                                             cll::init(1000));
 
-static cll::opt<unsigned long long>
-    src_node("startNode", // not uint64_t due to a bug in llvm cl
-             cll::desc("ID of the source node"), cll::init(0));
+static cll::opt<uint64_t>
+    src_node("startNode", cll::desc("ID of the source node"), cll::init(0));
 
 enum Exec { Sync, Async };
 
@@ -84,11 +83,11 @@ galois::graphs::GluonSubstrate<Graph>* syncSubstrate;
 
 struct InitializeGraph {
   const uint32_t& local_infinity;
-  cll::opt<unsigned long long>& local_src_node;
+  cll::opt<uint64_t>& local_src_node;
   Graph* graph;
 
-  InitializeGraph(cll::opt<unsigned long long>& _src_node,
-                  const uint32_t& _infinity, Graph* _graph)
+  InitializeGraph(cll::opt<uint64_t>& _src_node, const uint32_t& _infinity,
+                  Graph* _graph)
       : local_infinity(_infinity), local_src_node(_src_node), graph(_graph) {}
 
   void static go(Graph& _graph) {
@@ -271,7 +270,7 @@ int main(int argc, char** argv) {
     galois::runtime::reportParam(regionname, "Max Iterations",
                                  (unsigned long)maxIterations);
     galois::runtime::reportParam(regionname, "Source Node ID",
-                                 (unsigned long long)src_node);
+                                 uint64_t{src_node});
   }
   galois::StatTimer StatTimer_total("TimerTotal", regionname);
 

--- a/lonestar/analytics/distributed/bfs/bfs_pull.cpp
+++ b/lonestar/analytics/distributed/bfs/bfs_pull.cpp
@@ -19,9 +19,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/bfs/bfs_pull_cuda.cu
+++ b/lonestar/analytics/distributed/bfs/bfs_pull_cuda.cu
@@ -12,7 +12,7 @@ struct ThreadWork t_work;
 bool enable_lb = true;
 #include "bfs_pull_cuda.cuh"
 static const int __tb_BFS = TB_SIZE;
-__global__ void InitializeGraph(CSRGraph graph, unsigned int __begin, unsigned int __end, const uint32_t  local_infinity, unsigned long long local_src_node, uint32_t * p_dist_current)
+__global__ void InitializeGraph(CSRGraph graph, unsigned int __begin, unsigned int __end, const uint32_t  local_infinity, uint64_t local_src_node, uint32_t * p_dist_current)
 {
   unsigned tid = TID_1D;
   unsigned nthreads = TOTAL_THREADS_1D;
@@ -390,7 +390,7 @@ __global__ void BFSSanityCheck(CSRGraph graph, unsigned int __begin, unsigned in
   DGMax.thread_exit<cub::BlockReduce<uint32_t, TB_SIZE> >(DGMax_ts);
   // FP: "16 -> 17;
 }
-void InitializeGraph_cuda(unsigned int  __begin, unsigned int  __end, const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_cuda(unsigned int  __begin, unsigned int  __end, const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   t_work.init_thread_work(ctx->gg.nnodes);
   dim3 blocks;
@@ -406,19 +406,19 @@ void InitializeGraph_cuda(unsigned int  __begin, unsigned int  __end, const uint
   check_cuda_kernel;
   // FP: "6 -> 7;
 }
-void InitializeGraph_allNodes_cuda(const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_allNodes_cuda(const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   // FP: "1 -> 2;
   InitializeGraph_cuda(0, ctx->gg.nnodes, local_infinity, local_src_node, ctx);
   // FP: "2 -> 3;
 }
-void InitializeGraph_masterNodes_cuda(const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_masterNodes_cuda(const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   // FP: "1 -> 2;
   InitializeGraph_cuda(ctx->beginMaster, ctx->beginMaster + ctx->numOwned, local_infinity, local_src_node, ctx);
   // FP: "2 -> 3;
 }
-void InitializeGraph_nodesWithEdges_cuda(const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_nodesWithEdges_cuda(const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   // FP: "1 -> 2;
   InitializeGraph_cuda(0, ctx->numNodesWithEdges, local_infinity, local_src_node, ctx);

--- a/lonestar/analytics/distributed/bfs/bfs_pull_cuda.h
+++ b/lonestar/analytics/distributed/bfs/bfs_pull_cuda.h
@@ -79,14 +79,13 @@ void BFS_nodesWithEdges_cuda(unsigned int& active_vertices,
                              struct CUDA_Context* ctx);
 void InitializeGraph_cuda(unsigned int __begin, unsigned int __end,
                           const uint32_t& local_infinity,
-                          unsigned long long local_src_node,
-                          struct CUDA_Context* ctx);
+                          uint64_t local_src_node, struct CUDA_Context* ctx);
 void InitializeGraph_allNodes_cuda(const uint32_t& local_infinity,
-                                   unsigned long long local_src_node,
+                                   uint64_t local_src_node,
                                    struct CUDA_Context* ctx);
 void InitializeGraph_masterNodes_cuda(const uint32_t& local_infinity,
-                                      unsigned long long local_src_node,
+                                      uint64_t local_src_node,
                                       struct CUDA_Context* ctx);
 void InitializeGraph_nodesWithEdges_cuda(const uint32_t& local_infinity,
-                                         unsigned long long local_src_node,
+                                         uint64_t local_src_node,
                                          struct CUDA_Context* ctx);

--- a/lonestar/analytics/distributed/bfs/bfs_push.cpp
+++ b/lonestar/analytics/distributed/bfs/bfs_push.cpp
@@ -17,14 +17,11 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-// NOTE: must be before DistBenchStart.h as that relies on some cuda
-// calls
-
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/bfs/bfs_push.cpp
+++ b/lonestar/analytics/distributed/bfs/bfs_push.cpp
@@ -47,9 +47,8 @@ static cll::opt<unsigned int> maxIterations("maxIterations",
                                                       "Default 1000"),
                                             cll::init(1000));
 
-static cll::opt<unsigned long long>
-    src_node("startNode", // not uint64_t due to a bug in llvm cl
-             cll::desc("ID of the source node"), cll::init(0));
+static cll::opt<uint64_t>
+    src_node("startNode", cll::desc("ID of the source node"), cll::init(0));
 
 static cll::opt<uint32_t>
     delta("delta",
@@ -90,11 +89,11 @@ galois::graphs::GluonSubstrate<Graph>* syncSubstrate;
 
 struct InitializeGraph {
   const uint32_t& local_infinity;
-  cll::opt<unsigned long long>& local_src_node;
+  cll::opt<uint64_t>& local_src_node;
   Graph* graph;
 
-  InitializeGraph(cll::opt<unsigned long long>& _src_node,
-                  const uint32_t& _infinity, Graph* _graph)
+  InitializeGraph(cll::opt<uint64_t>& _src_node, const uint32_t& _infinity,
+                  Graph* _graph)
       : local_infinity(_infinity), local_src_node(_src_node), graph(_graph) {}
 
   void static go(Graph& _graph) {
@@ -369,7 +368,7 @@ int main(int argc, char** argv) {
     galois::runtime::reportParam(regionname, "Max Iterations",
                                  (unsigned long)maxIterations);
     galois::runtime::reportParam(regionname, "Source Node ID",
-                                 (unsigned long long)src_node);
+                                 uint64_t{src_node});
   }
 
   galois::StatTimer StatTimer_total("TimerTotal", regionname);

--- a/lonestar/analytics/distributed/bfs/bfs_push.cpp
+++ b/lonestar/analytics/distributed/bfs/bfs_push.cpp
@@ -17,14 +17,16 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#include <iostream>
-#include <limits>
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"
+
+#include <iostream>
+#include <limits>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "bfs_push_cuda.h"
@@ -34,7 +36,7 @@ enum { CPU, GPU_CUDA };
 int personality = CPU;
 #endif
 
-constexpr static const char* const regionname = "BFS";
+constexpr static const char* const REGION_NAME = "BFS";
 
 /******************************************************************************/
 /* Declaration of command line arguments */
@@ -103,7 +105,7 @@ struct InitializeGraph {
 #ifdef GALOIS_ENABLE_GPU
       std::string impl_str(
           syncSubstrate->get_run_identifier("InitializeGraph_"));
-      galois::StatTimer StatTimer_cuda(impl_str.c_str(), regionname);
+      galois::StatTimer StatTimer_cuda(impl_str.c_str(), REGION_NAME);
       StatTimer_cuda.start();
       InitializeGraph_allNodes_cuda(infinity, src_node, cuda_ctx);
       StatTimer_cuda.stop();
@@ -147,7 +149,7 @@ struct FirstItr_BFS {
     if (personality == GPU_CUDA) {
 #ifdef GALOIS_ENABLE_GPU
       std::string impl_str(syncSubstrate->get_run_identifier("BFS"));
-      galois::StatTimer StatTimer_cuda(impl_str.c_str(), regionname);
+      galois::StatTimer StatTimer_cuda(impl_str.c_str(), REGION_NAME);
       StatTimer_cuda.start();
       FirstItr_BFS_cuda(__begin, __end, cuda_ctx);
       StatTimer_cuda.stop();
@@ -166,7 +168,7 @@ struct FirstItr_BFS {
                         Bitset_dist_current, async>("BFS");
 
     galois::runtime::reportStat_Tsum(
-        regionname, syncSubstrate->get_run_identifier("NumWorkItems"),
+        REGION_NAME, syncSubstrate->get_run_identifier("NumWorkItems"),
         __end - __begin);
   }
 
@@ -228,7 +230,7 @@ struct BFS {
       if (personality == GPU_CUDA) {
 #ifdef GALOIS_ENABLE_GPU
         std::string impl_str(syncSubstrate->get_run_identifier("BFS"));
-        galois::StatTimer StatTimer_cuda(impl_str.c_str(), regionname);
+        galois::StatTimer StatTimer_cuda(impl_str.c_str(), REGION_NAME);
         StatTimer_cuda.start();
         unsigned int __retval  = 0;
         unsigned int __retval2 = 0;
@@ -250,7 +252,7 @@ struct BFS {
                           Bitset_dist_current, async>("BFS");
 
       galois::runtime::reportStat_Tsum(
-          regionname, syncSubstrate->get_run_identifier("NumWorkItems"),
+          REGION_NAME, syncSubstrate->get_run_identifier("NumWorkItems"),
           (unsigned long)work_edges.read_local());
 
       ++_num_iterations;
@@ -258,7 +260,7 @@ struct BFS {
              dga.reduce(syncSubstrate->get_run_identifier()));
 
     galois::runtime::reportStat_Tmax(
-        regionname,
+        REGION_NAME,
         "NumIterations_" + std::to_string(syncSubstrate->get_run_num()),
         (unsigned long)_num_iterations);
   }
@@ -350,6 +352,47 @@ struct BFSSanityCheck {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<uint32_t> makeResultsCPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).dist_current);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<uint32_t> makeResultsGPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_dist_current_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<uint32_t> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<uint32_t> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main */
 /******************************************************************************/
 
@@ -357,7 +400,7 @@ constexpr static const char* const name =
     "BFS - Distributed Heterogeneous with "
     "worklist.";
 constexpr static const char* const desc = "BFS on Distributed Galois.";
-constexpr static const char* const url  = 0;
+constexpr static const char* const url  = nullptr;
 
 int main(int argc, char** argv) {
   galois::DistMemSys G;
@@ -365,13 +408,13 @@ int main(int argc, char** argv) {
 
   const auto& net = galois::runtime::getSystemNetworkInterface();
   if (net.ID == 0) {
-    galois::runtime::reportParam(regionname, "Max Iterations",
-                                 (unsigned long)maxIterations);
-    galois::runtime::reportParam(regionname, "Source Node ID",
+    galois::runtime::reportParam(REGION_NAME, "Max Iterations",
+                                 (unsigned int){maxIterations});
+    galois::runtime::reportParam(REGION_NAME, "Source Node ID",
                                  uint64_t{src_node});
   }
 
-  galois::StatTimer StatTimer_total("TimerTotal", regionname);
+  galois::StatTimer StatTimer_total("TimerTotal", REGION_NAME);
 
   StatTimer_total.start();
 
@@ -397,7 +440,7 @@ int main(int argc, char** argv) {
   for (auto run = 0; run < numRuns; ++run) {
     galois::gPrint("[", net.ID, "] BFS::go run ", run, " called\n");
     std::string timer_str("Timer_" + std::to_string(run));
-    galois::StatTimer StatTimer_main(timer_str.c_str(), regionname);
+    galois::StatTimer StatTimer_main(timer_str.c_str(), REGION_NAME);
 
     StatTimer_main.start();
     if (execution == Async) {
@@ -429,25 +472,10 @@ int main(int argc, char** argv) {
 
   StatTimer_total.stop();
 
-  // Verify
-  if (verify) {
-    if (personality == CPU) {
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     (*hg).getData(*ii).dist_current);
-      }
-    } else if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     get_node_dist_current_cuda(cuda_ctx, *ii));
-      }
-#else
-      abort();
-#endif
-    }
+  if (output) {
+    std::vector<uint32_t> results = makeResults(hg);
+
+    writeOutput(outputLocation, "level", results.data(), results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/bfs/bfs_push_cuda.cu
+++ b/lonestar/analytics/distributed/bfs/bfs_push_cuda.cu
@@ -13,7 +13,7 @@ bool enable_lb = true;
 #include "bfs_push_cuda.cuh"
 static const int __tb_BFS = TB_SIZE;
 static const int __tb_FirstItr_BFS = TB_SIZE;
-__global__ void InitializeGraph(CSRGraph graph, unsigned int __begin, unsigned int __end, const uint32_t  local_infinity, unsigned long long local_src_node, uint32_t * p_dist_current, uint32_t * p_dist_old)
+__global__ void InitializeGraph(CSRGraph graph, unsigned int __begin, unsigned int __end, const uint32_t  local_infinity, uint64_t local_src_node, uint32_t * p_dist_current, uint32_t * p_dist_old)
 {
   unsigned tid = TID_1D;
   unsigned nthreads = TOTAL_THREADS_1D;
@@ -729,7 +729,7 @@ __global__ void BFSSanityCheck(CSRGraph graph, unsigned int __begin, unsigned in
   DGMax.thread_exit<cub::BlockReduce<uint32_t, TB_SIZE> >(DGMax_ts);
   // FP: "16 -> 17;
 }
-void InitializeGraph_cuda(unsigned int  __begin, unsigned int  __end, const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_cuda(unsigned int  __begin, unsigned int  __end, const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   t_work.init_thread_work(ctx->gg.nnodes);
   dim3 blocks;
@@ -745,19 +745,19 @@ void InitializeGraph_cuda(unsigned int  __begin, unsigned int  __end, const uint
   check_cuda_kernel;
   // FP: "6 -> 7;
 }
-void InitializeGraph_allNodes_cuda(const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_allNodes_cuda(const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   // FP: "1 -> 2;
   InitializeGraph_cuda(0, ctx->gg.nnodes, local_infinity, local_src_node, ctx);
   // FP: "2 -> 3;
 }
-void InitializeGraph_masterNodes_cuda(const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_masterNodes_cuda(const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   // FP: "1 -> 2;
   InitializeGraph_cuda(ctx->beginMaster, ctx->beginMaster + ctx->numOwned, local_infinity, local_src_node, ctx);
   // FP: "2 -> 3;
 }
-void InitializeGraph_nodesWithEdges_cuda(const uint32_t & local_infinity, unsigned long long local_src_node, struct CUDA_Context*  ctx)
+void InitializeGraph_nodesWithEdges_cuda(const uint32_t & local_infinity, uint64_t local_src_node, struct CUDA_Context*  ctx)
 {
   // FP: "1 -> 2;
   InitializeGraph_cuda(0, ctx->numNodesWithEdges, local_infinity, local_src_node, ctx);

--- a/lonestar/analytics/distributed/bfs/bfs_push_cuda.h
+++ b/lonestar/analytics/distributed/bfs/bfs_push_cuda.h
@@ -133,14 +133,13 @@ void FirstItr_BFS_masterNodes_cuda(struct CUDA_Context* ctx);
 void FirstItr_BFS_nodesWithEdges_cuda(struct CUDA_Context* ctx);
 void InitializeGraph_cuda(unsigned int __begin, unsigned int __end,
                           const uint32_t& local_infinity,
-                          unsigned long long local_src_node,
-                          struct CUDA_Context* ctx);
+                          uint64_t local_src_node, struct CUDA_Context* ctx);
 void InitializeGraph_allNodes_cuda(const uint32_t& local_infinity,
-                                   unsigned long long local_src_node,
+                                   uint64_t local_src_node,
                                    struct CUDA_Context* ctx);
 void InitializeGraph_masterNodes_cuda(const uint32_t& local_infinity,
-                                      unsigned long long local_src_node,
+                                      uint64_t local_src_node,
                                       struct CUDA_Context* ctx);
 void InitializeGraph_nodesWithEdges_cuda(const uint32_t& local_infinity,
-                                         unsigned long long local_src_node,
+                                         uint64_t local_src_node,
                                          struct CUDA_Context* ctx);

--- a/lonestar/analytics/distributed/cc/cc_pull.cpp
+++ b/lonestar/analytics/distributed/cc/cc_pull.cpp
@@ -17,14 +17,16 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#include <iostream>
-#include <limits>
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
-#include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
+#include "galois/gstl.h"
 #include "galois/runtime/Tracer.h"
+
+#include <iostream>
+#include <limits>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "cc_pull_cuda.h"
@@ -236,6 +238,47 @@ struct ConnectedCompSanityCheck {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<uint32_t> makeResultsCPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).comp_current);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<uint32_t> makeResultsGPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_comp_current_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<uint32_t> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<uint32_t> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main */
 /******************************************************************************/
 
@@ -243,7 +286,7 @@ constexpr static const char* const name = "ConnectedComp Pull - Distributed "
                                           "Heterogeneous";
 constexpr static const char* const desc = "ConnectedComp pull on Distributed "
                                           "Galois.";
-constexpr static const char* const url = 0;
+constexpr static const char* const url = nullptr;
 
 int main(int argc, char** argv) {
   galois::DistMemSys G;
@@ -253,7 +296,7 @@ int main(int argc, char** argv) {
 
   if (net.ID == 0) {
     galois::runtime::reportParam(REGION_NAME, "Max Iterations",
-                                 (unsigned long)maxIterations);
+                                 (unsigned int){maxIterations});
   }
 
   galois::StatTimer StatTimer_total("TimerTotal", REGION_NAME);
@@ -311,28 +354,10 @@ int main(int argc, char** argv) {
 
   StatTimer_total.stop();
 
-  // Verify
-  if (verify) {
-    if (personality == CPU) {
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        if ((*hg).isOwned((*hg).getGID(*ii)))
-          galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                       (*hg).getData(*ii).comp_current);
-      }
-    } else if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        if ((*hg).isOwned((*hg).getGID(*ii)))
-          galois::runtime::printOutput(
-              "% %\n", (*hg).getGID(*ii),
-              get_node_comp_current_cuda(cuda_ctx, *ii));
-      }
-#else
-      abort();
-#endif
-    }
+  if (output) {
+    std::vector<uint32_t> results = makeResults(hg);
+
+    writeOutput(outputLocation, "component", results.data(), results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/cc/cc_pull.cpp
+++ b/lonestar/analytics/distributed/cc/cc_pull.cpp
@@ -19,9 +19,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/cc/cc_push.cpp
+++ b/lonestar/analytics/distributed/cc/cc_push.cpp
@@ -17,14 +17,16 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#include <iostream>
-#include <limits>
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
-#include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
+#include "galois/gstl.h"
 #include "galois/runtime/Tracer.h"
+
+#include <iostream>
+#include <limits>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "cc_push_cuda.h"
@@ -295,6 +297,47 @@ struct ConnectedCompSanityCheck {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<uint32_t> makeResultsCPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).comp_current);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<uint32_t> makeResultsGPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_comp_current_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<uint32_t> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<uint32_t> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main */
 /******************************************************************************/
 
@@ -302,7 +345,7 @@ constexpr static const char* const name = "ConnectedComp - Distributed "
                                           "Heterogeneous with filter.";
 constexpr static const char* const desc =
     "ConnectedComp on Distributed Galois.";
-constexpr static const char* const url = 0;
+constexpr static const char* const url = nullptr;
 
 int main(int argc, char** argv) {
   galois::DistMemSys G;
@@ -312,7 +355,7 @@ int main(int argc, char** argv) {
 
   if (net.ID == 0) {
     galois::runtime::reportParam(REGION_NAME, "Max Iterations",
-                                 (unsigned long)maxIterations);
+                                 (unsigned int){maxIterations});
   }
 
   galois::StatTimer StatTimer_total("TimerTotal", REGION_NAME);
@@ -371,25 +414,10 @@ int main(int argc, char** argv) {
 
   StatTimer_total.stop();
 
-  // Verify
-  if (verify) {
-    if (personality == CPU) {
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     (*hg).getData(*ii).comp_current);
-      }
-    } else if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     get_node_comp_current_cuda(cuda_ctx, *ii));
-      }
-#else
-      abort();
-#endif
-    }
+  if (output) {
+    std::vector<uint32_t> results = makeResults(hg);
+
+    writeOutput(outputLocation, "component", results.data(), results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/cc/cc_push.cpp
+++ b/lonestar/analytics/distributed/cc/cc_push.cpp
@@ -19,9 +19,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/kcore/kcore_pull.cpp
+++ b/lonestar/analytics/distributed/kcore/kcore_pull.cpp
@@ -23,9 +23,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/kcore/kcore_push.cpp
+++ b/lonestar/analytics/distributed/kcore/kcore_push.cpp
@@ -21,14 +21,16 @@
 /* Sync code/calls was manually written, not compiler generated */
 /******************************************************************************/
 
-#include <iostream>
-#include <limits>
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
-#include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
+#include "galois/gstl.h"
 #include "galois/runtime/Tracer.h"
+
+#include <iostream>
+#include <limits>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "kcore_push_cuda.h"
@@ -362,13 +364,54 @@ struct KCoreSanityCheck {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<uint8_t> makeResultsCPU(Graph* hg) {
+  std::vector<uint8_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).flag);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<uint8_t> makeResultsGPU(Graph* hg) {
+  std::vector<uint8_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_flag_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<uint8_t> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<uint8_t> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main method for running */
 /******************************************************************************/
 
 constexpr static const char* const name = "KCore - Distributed Heterogeneous "
                                           "Push Filter.";
 constexpr static const char* const desc = "KCore on Distributed Galois.";
-constexpr static const char* const url  = 0;
+constexpr static const char* const url  = nullptr;
 
 int main(int argc, char** argv) {
   galois::DistMemSys G;
@@ -377,7 +420,7 @@ int main(int argc, char** argv) {
   auto& net = galois::runtime::getSystemNetworkInterface();
   if (net.ID == 0) {
     galois::runtime::reportParam(REGION_NAME, "Max Iterations",
-                                 (unsigned long)maxIterations);
+                                 (unsigned int){maxIterations});
   }
 
   galois::StatTimer StatTimer_total("TimerTotal", REGION_NAME);
@@ -434,39 +477,17 @@ int main(int argc, char** argv) {
         bitset_trim.reset();
       }
 
-      InitializeGraph1::go((*h_graph));
+      InitializeGraph1::go(*h_graph);
       galois::runtime::getHostBarrier().wait();
     }
   }
 
   StatTimer_total.stop();
 
-  // Verify, i.e. print out graph data for examination
-  if (verify) {
-    if (personality == CPU) {
-      for (auto ii = (*h_graph).masterNodesRange().begin();
-           ii != (*h_graph).masterNodesRange().end(); ++ii) {
-        // prints the flag (alive/dead)
-        galois::runtime::printOutput("% %\n", (*h_graph).getGID(*ii),
-                                     (bool)(*h_graph).getData(*ii).flag);
+  if (output) {
+    std::vector<uint8_t> results = makeResults(h_graph);
 
-        // does a sanity check as well:
-        // degree higher than kcore if node is alive
-        if (!((*h_graph).getData(*ii).flag)) {
-          assert((*h_graph).getData(*ii).current_degree < k_core_num);
-        }
-      }
-    } else if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*h_graph).masterNodesRange().begin();
-           ii != (*h_graph).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*h_graph).getGID(*ii),
-                                     (bool)get_node_flag_cuda(cuda_ctx, *ii));
-      }
-#else
-      abort();
-#endif
-    }
+    writeOutput(outputLocation, "in_kcore", results.data(), results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/kcore/kcore_push.cpp
+++ b/lonestar/analytics/distributed/kcore/kcore_push.cpp
@@ -23,9 +23,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/pagerank/pagerank_pull.cpp
+++ b/lonestar/analytics/distributed/pagerank/pagerank_pull.cpp
@@ -17,8 +17,8 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
-#include "DistBenchStart.h"
 #include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"

--- a/lonestar/analytics/distributed/pagerank/pagerank_push.cpp
+++ b/lonestar/analytics/distributed/pagerank/pagerank_push.cpp
@@ -17,8 +17,8 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
-#include "DistBenchStart.h"
 #include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"

--- a/lonestar/analytics/distributed/pagerank/pagerank_push.cpp
+++ b/lonestar/analytics/distributed/pagerank/pagerank_push.cpp
@@ -17,12 +17,18 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"
+
+#include <algorithm>
+#include <iostream>
+#include <limits>
+#include <vector>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "pagerank_push_cuda.h"
@@ -31,11 +37,6 @@ struct CUDA_Context* cuda_ctx;
 enum { CPU, GPU_CUDA };
 int personality = CPU;
 #endif
-
-#include <iostream>
-#include <limits>
-#include <algorithm>
-#include <vector>
 
 constexpr static const char* const REGION_NAME = "PageRank";
 
@@ -429,6 +430,47 @@ struct PageRankSanity {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<float> makeResultsCPU(Graph* hg) {
+  std::vector<float> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).value);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<float> makeResultsGPU(Graph* hg) {
+  std::vector<float> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_value_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<float> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<float> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main */
 /******************************************************************************/
 
@@ -446,7 +488,7 @@ int main(int argc, char** argv) {
 
   if (net.ID == 0) {
     galois::runtime::reportParam(REGION_NAME, "Max Iterations",
-                                 (unsigned long)maxIterations);
+                                 (unsigned int){maxIterations});
     std::ostringstream ss;
     ss << tolerance;
     galois::runtime::reportParam(REGION_NAME, "Tolerance", ss.str());
@@ -518,25 +560,10 @@ int main(int argc, char** argv) {
 
   StatTimer_total.stop();
 
-  // Verify
-  if (verify) {
-    if (personality == CPU) {
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     (*hg).getData(*ii).value);
-      }
-    } else if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     get_node_value_cuda(cuda_ctx, *ii));
-      }
-#else
-      abort();
-#endif
-    }
+  if (output) {
+    std::vector<float> results = makeResults(hg);
+
+    writeOutput(outputLocation, "pagerank", results.data(), results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/partition/partition.cpp
+++ b/lonestar/analytics/distributed/partition/partition.cpp
@@ -17,14 +17,11 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-// NOTE: must be before DistBenchStart.h as that relies on some cuda
-// calls
-
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 
 /******************************************************************************/
 /* Declaration of command line arguments */

--- a/lonestar/analytics/distributed/sgd/sgd.cpp
+++ b/lonestar/analytics/distributed/sgd/sgd.cpp
@@ -20,13 +20,12 @@
 #include <iostream>
 #include <limits>
 #include <cmath>
-#include "galois/DistGalois.h"
-#include "galois/gstl.h"
-#include "DistBenchStart.h"
-
-#include "galois/DReducible.h"
-#include "galois/AtomicWrapper.h"
+#include "DistBench/Start.h"
 #include "galois/ArrayWrapper.h"
+#include "galois/AtomicWrapper.h"
+#include "galois/DistGalois.h"
+#include "galois/DReducible.h"
+#include "galois/gstl.h"
 #include "galois/runtime/Tracer.h"
 
 #ifdef GALOIS_ENABLE_GPU

--- a/lonestar/analytics/distributed/sssp/sssp_pull.cpp
+++ b/lonestar/analytics/distributed/sssp/sssp_pull.cpp
@@ -19,9 +19,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/sssp/sssp_pull.cpp
+++ b/lonestar/analytics/distributed/sssp/sssp_pull.cpp
@@ -283,7 +283,7 @@ int main(int argc, char** argv) {
     galois::runtime::reportParam(REGION_NAME, "Max Iterations",
                                  (unsigned long)maxIterations);
     galois::runtime::reportParam(REGION_NAME, "Source Node ID",
-                                 (unsigned long long)src_node);
+                                 uint64_t{src_node});
   }
 
   galois::StatTimer StatTimer_total("TimerTotal", REGION_NAME);

--- a/lonestar/analytics/distributed/sssp/sssp_pull.cpp
+++ b/lonestar/analytics/distributed/sssp/sssp_pull.cpp
@@ -17,14 +17,16 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#include <iostream>
-#include <limits>
+#include "DistBench/Output.h"
 #include "DistBench/Start.h"
 #include "galois/DistGalois.h"
-#include "galois/gstl.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
+#include "galois/gstl.h"
 #include "galois/runtime/Tracer.h"
+
+#include <iostream>
+#include <limits>
 
 #ifdef GALOIS_ENABLE_GPU
 #include "sssp_pull_cuda.h"
@@ -266,13 +268,54 @@ struct SSSPSanityCheck {
 };
 
 /******************************************************************************/
+/* Make results */
+/******************************************************************************/
+
+std::vector<uint32_t> makeResultsCPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(hg->getData(node).dist_current);
+  }
+
+  return values;
+}
+
+#ifdef GALOIS_ENABLE_GPU
+std::vector<uint32_t> makeResultsGPU(Graph* hg) {
+  std::vector<uint32_t> values;
+
+  values.reserve(hg->numMasters());
+  for (auto node : hg->masterNodesRange()) {
+    values.push_back(get_node_dist_current_cuda(cuda_ctx, node));
+  }
+
+  return values;
+}
+#else
+std::vector<uint32_t> makeResultsGPU(Graph* /*unused*/) { abort(); }
+#endif
+
+std::vector<uint32_t> makeResults(Graph* hg) {
+  switch (personality) {
+  case CPU:
+    return makeResultsCPU(hg);
+  case GPU_CUDA:
+    return makeResultsGPU(hg);
+  default:
+    abort();
+  }
+}
+
+/******************************************************************************/
 /* Main */
 /******************************************************************************/
 
 constexpr static const char* const name = "SSSP pull - Distributed "
                                           "Heterogeneous";
 constexpr static const char* const desc = "SSSP pull on Distributed Galois.";
-constexpr static const char* const url  = 0;
+constexpr static const char* const url  = nullptr;
 
 int main(int argc, char** argv) {
   galois::DistMemSys G;
@@ -281,7 +324,7 @@ int main(int argc, char** argv) {
   auto& net = galois::runtime::getSystemNetworkInterface();
   if (net.ID == 0) {
     galois::runtime::reportParam(REGION_NAME, "Max Iterations",
-                                 (unsigned long)maxIterations);
+                                 (unsigned int){maxIterations});
     galois::runtime::reportParam(REGION_NAME, "Source Node ID",
                                  uint64_t{src_node});
   }
@@ -346,25 +389,10 @@ int main(int argc, char** argv) {
 
   StatTimer_total.stop();
 
-  // Verify
-  if (verify) {
-    if (personality == CPU) {
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     (*hg).getData(*ii).dist_current);
-      }
-    } else if (personality == GPU_CUDA) {
-#ifdef GALOIS_ENABLE_GPU
-      for (auto ii = (*hg).masterNodesRange().begin();
-           ii != (*hg).masterNodesRange().end(); ++ii) {
-        galois::runtime::printOutput("% %\n", (*hg).getGID(*ii),
-                                     get_node_dist_current_cuda(cuda_ctx, *ii));
-      }
-#else
-      abort();
-#endif
-    }
+  if (output) {
+    std::vector<uint32_t> results = makeResults(hg);
+
+    writeOutput(outputLocation, "distance", results.data(), results.size());
   }
 
   return 0;

--- a/lonestar/analytics/distributed/sssp/sssp_push.cpp
+++ b/lonestar/analytics/distributed/sssp/sssp_push.cpp
@@ -377,8 +377,7 @@ int main(int argc, char** argv) {
   if (net.ID == 0) {
     galois::runtime::reportParam("SSSP", "Max Iterations",
                                  (unsigned long)maxIterations);
-    galois::runtime::reportParam("SSSP", "Source Node ID",
-                                 (unsigned long)src_node);
+    galois::runtime::reportParam("SSSP", "Source Node ID", uint64_t{src_node});
   }
 
   galois::StatTimer StatTimer_total("TimerTotal", REGION_NAME);

--- a/lonestar/analytics/distributed/sssp/sssp_push.cpp
+++ b/lonestar/analytics/distributed/sssp/sssp_push.cpp
@@ -19,9 +19,9 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/Start.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
-#include "DistBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/analytics/distributed/tc/tc.cpp
+++ b/lonestar/analytics/distributed/tc/tc.cpp
@@ -26,11 +26,11 @@
 
 #include <iostream>
 #include <limits>
+#include "DistBench/MiningStart.h"
 #include "galois/DistGalois.h"
 #include "galois/gstl.h"
 #include "galois/graphs/MiningPartitioner.h"
 #include "galois/graphs/GenericPartitioners.h"
-#include "DistMiningBenchStart.h"
 #include "galois/DReducible.h"
 #include "galois/DTerminationDetector.h"
 #include "galois/runtime/Tracer.h"

--- a/lonestar/libdistbench/CMakeLists.txt
+++ b/lonestar/libdistbench/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories("${PROJECT_SOURCE_DIR}/libgluon/include")
 include_directories("${PROJECT_SOURCE_DIR}/lonestardist/include")
 
-add_library(distbench STATIC src/DistBenchStart.cpp src/DistributedGraphLoader.cpp)
+add_library(distbench STATIC src/Start.cpp src/Input.cpp)
 target_include_directories(distbench PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )

--- a/lonestar/libdistbench/CMakeLists.txt
+++ b/lonestar/libdistbench/CMakeLists.txt
@@ -1,6 +1,3 @@
-include_directories("${PROJECT_SOURCE_DIR}/libgluon/include")
-include_directories("${PROJECT_SOURCE_DIR}/lonestardist/include")
-
 add_library(distbench STATIC src/Start.cpp src/Input.cpp)
 target_include_directories(distbench PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/include"

--- a/lonestar/libdistbench/CMakeLists.txt
+++ b/lonestar/libdistbench/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(distbench STATIC src/Start.cpp src/Input.cpp)
+add_library(distbench STATIC src/Start.cpp src/Input.cpp src/Output.cpp)
 target_include_directories(distbench PUBLIC
   "${CMAKE_CURRENT_SOURCE_DIR}/include"
 )

--- a/lonestar/libdistbench/include/DistBench/MiningStart.h
+++ b/lonestar/libdistbench/include/DistBench/MiningStart.h
@@ -47,9 +47,9 @@ namespace cll = llvm::cl;
 extern cll::opt<int> numThreads;
 extern cll::opt<int> numRuns;
 extern cll::opt<std::string> statFile;
-extern cll::opt<bool> verify;
 //! Set method for metadata sends
 extern cll::opt<DataCommMode> commMetadata;
+extern cll::opt<bool> output;
 
 #ifdef GALOIS_ENABLE_GPU
 enum Personality { CPU, GPU_CUDA };

--- a/lonestar/libdistbench/include/DistBench/MiningStart.h
+++ b/lonestar/libdistbench/include/DistBench/MiningStart.h
@@ -20,17 +20,17 @@
 // TODO document + merge with regular bench start? have to figure out how to
 // have both substrates coexist
 
-#ifndef _DIST_MINE_BENCH_START_H_
-#define _DIST_MINE_BENCH_START_H_
+#ifndef GALOIS_DISTBENCH_MININGSTART_H
+#define GALOIS_DISTBENCH_MININGSTART_H
 
+#include "DistBench/Input.h"
+#include "galois/AtomicHelpers.h"
 #include "galois/Galois.h"
-#include "galois/Version.h"
-#include "llvm/Support/CommandLine.h"
-#include "galois/graphs/MiningPartitioner.h"
 #include "galois/graphs/GenericPartitioners.h"
 #include "galois/graphs/GluonEdgeSubstrate.h"
-#include "DistributedGraphLoader.h"
-#include "galois/AtomicHelpers.h"
+#include "galois/graphs/MiningPartitioner.h"
+#include "galois/Version.h"
+#include "llvm/Support/CommandLine.h"
 
 #ifdef GALOIS_ENABLE_GPU
 #include "galois/cuda/EdgeHostDecls.h"

--- a/lonestar/libdistbench/include/DistBench/Output.h
+++ b/lonestar/libdistbench/include/DistBench/Output.h
@@ -1,0 +1,23 @@
+#ifndef GALOIS_DISTBENCH_OUTPUT_H
+#define GALOIS_DISTBENCH_OUTPUT_H
+
+#include <filesystem>
+#include <string>
+#include <vector>
+#include <fstream>
+
+std::string makeOutputFilename(const std::string& outputDir);
+
+template <typename T>
+void writeOutput(const std::string& outputDir, const std::string& /*fieldName*/,
+                 T* values, size_t length) {
+  std::string filename = makeOutputFilename(outputDir);
+
+  std::ofstream outputFile(filename.c_str());
+
+  for (size_t i = 0; i < length; i++) {
+    outputFile << *(values++) << "\n";
+  }
+}
+
+#endif

--- a/lonestar/libdistbench/include/DistBench/Output.h
+++ b/lonestar/libdistbench/include/DistBench/Output.h
@@ -1,9 +1,7 @@
 #ifndef GALOIS_DISTBENCH_OUTPUT_H
 #define GALOIS_DISTBENCH_OUTPUT_H
 
-#include <filesystem>
 #include <string>
-#include <vector>
 #include <fstream>
 
 std::string makeOutputFilename(const std::string& outputDir);

--- a/lonestar/libdistbench/include/DistBench/Start.h
+++ b/lonestar/libdistbench/include/DistBench/Start.h
@@ -133,7 +133,7 @@ static void marshalGPUGraph(
  */
 template <typename NodeData, typename EdgeData, bool iterateOutEdges = true>
 static galois::graphs::DistGraph<NodeData, EdgeData>*
-loadDGraph(std::vector<unsigned>& scaleFactor) {
+loadDistGraph(std::vector<unsigned>& scaleFactor) {
   galois::StatTimer dGraphTimer("GraphConstructTime", "DistBench");
   dGraphTimer.start();
 
@@ -167,7 +167,7 @@ loadDGraph(std::vector<unsigned>& scaleFactor) {
  */
 template <typename NodeData, typename EdgeData>
 static galois::graphs::DistGraph<NodeData, EdgeData>*
-loadSymmetricDGraph(std::vector<unsigned>& scaleFactor) {
+loadSymmetricDistGraph(std::vector<unsigned>& scaleFactor) {
   galois::StatTimer dGraphTimer("GraphConstructTime", "DistBench");
   dGraphTimer.start();
 
@@ -225,7 +225,7 @@ distGraphInitialization() {
 #ifdef GALOIS_ENABLE_GPU
   internal::heteroSetup(scaleFactor);
 #endif
-  g = loadDGraph<NodeData, EdgeData, iterateOutEdges>(scaleFactor);
+  g = loadDistGraph<NodeData, EdgeData, iterateOutEdges>(scaleFactor);
   // load substrate
   const auto& net = galois::runtime::getSystemNetworkInterface();
   s = new Substrate(*g, net.ID, net.Num, g->isTransposed(), g->cartesianGrid(),
@@ -270,7 +270,7 @@ symmetricDistGraphInitialization() {
 #ifdef GALOIS_ENABLE_GPU
   internal::heteroSetup(scaleFactor);
 #endif
-  g = loadSymmetricDGraph<NodeData, EdgeData>(scaleFactor);
+  g = loadSymmetricDistGraph<NodeData, EdgeData>(scaleFactor);
   // load substrate
   const auto& net = galois::runtime::getSystemNetworkInterface();
   s = new Substrate(*g, net.ID, net.Num, g->isTransposed(), g->cartesianGrid(),

--- a/lonestar/libdistbench/include/DistBench/Start.h
+++ b/lonestar/libdistbench/include/DistBench/Start.h
@@ -17,15 +17,15 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#ifndef DIST_BENCH_START_H
-#define DIST_BENCH_START_H
+#ifndef GALOIS_DISTBENCH_START_H
+#define GALOIS_DISTBENCH_START_H
 
+#include "DistBench/Input.h"
+#include "galois/AtomicHelpers.h"
 #include "galois/Galois.h"
+#include "galois/graphs/GluonSubstrate.h"
 #include "galois/Version.h"
 #include "llvm/Support/CommandLine.h"
-#include "DistributedGraphLoader.h"
-#include "galois/graphs/GluonSubstrate.h"
-#include "galois/AtomicHelpers.h"
 
 #ifdef GALOIS_ENABLE_GPU
 #include "galois/cuda/HostDecls.h"
@@ -139,8 +139,7 @@ loadDGraph(std::vector<unsigned>& scaleFactor) {
 
   galois::graphs::DistGraph<NodeData, EdgeData>* loadedGraph = nullptr;
   loadedGraph =
-      galois::graphs::constructGraph<NodeData, EdgeData, iterateOutEdges>(
-          scaleFactor);
+      constructGraph<NodeData, EdgeData, iterateOutEdges>(scaleFactor);
   assert(loadedGraph != nullptr);
 
   dGraphTimer.stop();
@@ -176,8 +175,7 @@ loadSymmetricDGraph(std::vector<unsigned>& scaleFactor) {
 
   // make sure that the symmetric graph flag was passed in
   if (inputFileSymmetric) {
-    loadedGraph = galois::graphs::constructSymmetricGraph<NodeData, EdgeData>(
-        scaleFactor);
+    loadedGraph = constructSymmetricGraph<NodeData, EdgeData>(scaleFactor);
   } else {
     GALOIS_DIE("must use -symmetricGraph flag with a symmetric graph for "
                "this benchmark");

--- a/lonestar/libdistbench/include/DistBench/Start.h
+++ b/lonestar/libdistbench/include/DistBench/Start.h
@@ -41,11 +41,13 @@ namespace cll = llvm::cl;
 extern cll::opt<int> numThreads;
 extern cll::opt<int> numRuns;
 extern cll::opt<std::string> statFile;
-extern cll::opt<bool> verify;
 //! If set, ignore partitioning comm optimizations
 extern cll::opt<bool> partitionAgnostic;
 //! Set method for metadata sends
 extern cll::opt<DataCommMode> commMetadata;
+//! Where to write output if output is set
+extern cll::opt<std::string> outputLocation;
+extern cll::opt<bool> output;
 
 #ifdef GALOIS_ENABLE_GPU
 enum Personality { CPU, GPU_CUDA };

--- a/lonestar/libdistbench/src/Input.cpp
+++ b/lonestar/libdistbench/src/Input.cpp
@@ -18,13 +18,13 @@
  */
 
 /**
- * @file DistributedGraphLoader.cpp
+ * @file Reader.cpp
  *
  * Contains definitions for command line arguments related to distributed
  * graph loading.
  */
 
-#include "DistributedGraphLoader.h"
+#include "DistBench/Input.h"
 
 using namespace galois::graphs;
 
@@ -59,13 +59,6 @@ cll::opt<PARTITIONING_SCHEME> partitionScheme(
         clEnumValN(SUGAR_O, "sugar-o",
                    "fennel, incoming edge cut, using CuSP")),
     cll::init(OEC));
-
-// cll::opt<std::string>
-//    vertexIDMapFileName("vertexIDMapFileName",
-//                        cll::desc("<file containing the "
-//                                  "vertexID to hosts mapping for "
-//                                  "the custom edge cut.>"),
-//                        cll::init(""), cll::Hidden);
 
 cll::opt<bool> readFromFile("readFromFile",
                             cll::desc("Set this flag if graph is to be "

--- a/lonestar/libdistbench/src/Output.cpp
+++ b/lonestar/libdistbench/src/Output.cpp
@@ -1,0 +1,28 @@
+#include "DistBench/Output.h"
+#include "galois/runtime/Network.h"
+
+#include <iomanip>
+
+namespace {
+std::string zeroPad(int num, int width) {
+  std::ostringstream out;
+
+  out << std::setw(width) << std::setfill('0') << num;
+
+  return out.str();
+}
+
+} // namespace
+
+std::string makeOutputFilename(const std::string& outputDir) {
+  std::string filename = zeroPad(galois::runtime::getHostID(), 8);
+
+  std::string output{outputDir};
+  if (output.empty() || output.compare(output.size() - 1, 1, "/") == 0) {
+    output += filename;
+  } else {
+    output += "/" + filename;
+  }
+
+  return output;
+}

--- a/lonestar/libdistbench/src/Start.cpp
+++ b/lonestar/libdistbench/src/Start.cpp
@@ -17,7 +17,7 @@
  * Documentation, or loss or inaccuracy of data of any kind.
  */
 
-#include "DistBenchStart.h"
+#include "DistBench/Start.h"
 #include "galois/Version.h"
 #include "galois/runtime/Network.h"
 #include "galois/runtime/DistStats.h"

--- a/lonestar/libdistbench/src/Start.cpp
+++ b/lonestar/libdistbench/src/Start.cpp
@@ -34,12 +34,7 @@ cll::opt<int> numThreads("t", cll::desc("Number of threads (default 1)"),
 cll::opt<int> numRuns("runs", cll::desc("Number of runs (default 3)"),
                       cll::init(3));
 cll::opt<std::string>
-    statFile("statFile", cll::desc("optional output file to print stats to"),
-             cll::init(""));
-cll::opt<bool> verify("verify",
-                      cll::desc("Verify results by outputting results "
-                                "to file (default false)"),
-                      cll::init(false));
+    statFile("statFile", cll::desc("Optional output file to print stats to"));
 
 cll::opt<bool>
     partitionAgnostic("partitionAgnostic",
@@ -58,6 +53,13 @@ cll::opt<DataCommMode> commMetadata(
                            "Do not use any metadata (sends "
                            "non-updated values)")),
     cll::init(noData), cll::Hidden);
+
+cll::opt<std::string> outputLocation(
+    "outputLocation",
+    cll::desc("Location (directory) to write results to when output is true"));
+
+cll::opt<bool> output("output", cll::desc("Write result (default false)"),
+                      cll::init(false));
 
 #ifdef GALOIS_ENABLE_GPU
 std::string personality_str(Personality p) {


### PR DESCRIPTION
Add a command line option to write results `--outputLocation=string`/`--output`.

Downstream, we will be writing these out as parquet files probably, but there is no reason everyone can't benefit from the common extraction code. The output code is outside any timing region so this shouldn't affect benchmark results.

We intend to support remote storage backends like S3, which is why commands do not currently create the output directory if it is missing.

The output API (`writeOutput`) implicitly assumes that node data can just be concatenated together as there is no parameter for indices. We can technically support sparse node data, but as far as I could tell, the current interfaces do not yet expose this functionality (masterNode iterators are just `counting_iterator`s). So, I'm deferring this work until the graph interfaces/implications can change too.

I briefly considered adding parquet support here but I didn't want to upset the applecart during the release window. Also, the implementation of node data (properties) is still TBD; in particular, we might need to change the graph implementations from the implicit array of structs representation to a struct of arrays to get zero-copy serialization.

I know that there has been some discussion on the appropriate way to dispatch CPU versus GPU code #219. I haven't seen a resolution here, so I just continued the current path.

Tested locally. I had to manually work around #195:

```
ERROR: /home/ddn/w/katana/libgalois/src/FileGraph.cpp:304: No such file or directory: failed opening '/home/ddn/w/katana-build/inputs/Mining/citeseer.csgr'
...
The following tests FAILED:
        408 - run-small1-kcl-6 (Child aborted)
        409 - run-small1-kcl-3 (Child aborted)
        410 - run-small1-kcl-1 (Child aborted)
```
