### PR TITLE
Standardize uses of GALOIS_DIE

### DIFF
--- a/libcusp/include/galois/graphs/BasePolicies.h
+++ b/libcusp/include/galois/graphs/BasePolicies.h
@@ -219,7 +219,7 @@ public:
       }
     } else {
       // stage 0 = this function shouldn't be called
-      GALOIS_DIE("Master setup incomplete");
+      GALOIS_DIE("master setup incomplete");
       return (uint32_t)-1;
     }
   }
@@ -327,7 +327,7 @@ public:
         return false;
       }
     } else {
-      GALOIS_DIE("add master mapping should only be called in stage 0/1");
+      GALOIS_DIE("unexpected status in add master mapping: ", _status);
       return false;
     }
   }

--- a/libcusp/include/galois/graphs/MiningPartitioner.h
+++ b/libcusp/include/galois/graphs/MiningPartitioner.h
@@ -88,7 +88,7 @@ class MiningGraph : public DistGraph<NodeTy, EdgeTy> {
 
     uint64_t* outIndexBuffer = (uint64_t*)malloc(sizeof(uint64_t) * numNodes);
     if (outIndexBuffer == nullptr) {
-      GALOIS_DIE("OOM, get node degrees");
+      GALOIS_DIE("out of memory");
     }
     uint64_t numBytesToLoad = numNodes * sizeof(uint64_t);
     uint64_t bytesRead      = 0;
@@ -699,7 +699,7 @@ private:
         // no data sent; just clear again
         numOutgoingEdges[sendingHost].clear();
       } else {
-        GALOIS_DIE("invalid recv inspection data metadata mode, outgoing");
+        GALOIS_DIE("unreachable: ", outgoingExists);
       }
     }
 
@@ -864,7 +864,7 @@ public:
         return *edge;
       }
     }
-    GALOIS_DIE("edge lid should be found from edge gid");
+    GALOIS_DIE("unreachable");
     return (uint64_t)-1;
   }
 
@@ -883,7 +883,7 @@ public:
       }
     }
 
-    GALOIS_DIE("source not found for edge, shouldn't happen");
+    GALOIS_DIE("unreachable");
     return (uint32_t)-1;
   }
 

--- a/libcusp/include/galois/graphs/NewGeneric.h
+++ b/libcusp/include/galois/graphs/NewGeneric.h
@@ -713,7 +713,8 @@ private:
           assert(!loadsClear.test(sendingHost));
           loadsClear.set(sendingHost);
         } else {
-          GALOIS_DIE("Invalid message type for async load synchronization");
+          GALOIS_DIE("unexpected message type in async load synchronization: ",
+                     messageType);
         }
       }
     } while (p);
@@ -961,7 +962,7 @@ private:
         } else if (phase == 0) {
           net.sendTagged(h, galois::runtime::evilPhase, b);
         } else {
-          GALOIS_DIE("phase in send all clears should be 0 or 1");
+          GALOIS_DIE("unexpected phase: ", phase);
         }
       }
     }
@@ -1030,7 +1031,8 @@ private:
       galois::runtime::gDeserialize(p->second, receivedOffsets);
       galois::runtime::gDeserialize(p->second, receivedMasters);
     } else if (messageType != 0) {
-      GALOIS_DIE("Invalid message type for sync of master assignments");
+      GALOIS_DIE("invalid message type for sync of master assignments: ",
+                 messageType);
     }
 
     galois::gDebug("[", base_DistGraph::id, "] host ", sendingHost,
@@ -1087,7 +1089,8 @@ private:
           assert(!hostFinished.test(sendingHost));
           hostFinished.set(sendingHost);
         } else if (messageType != 0) {
-          GALOIS_DIE("Invalid message type for sync of master assignments");
+          GALOIS_DIE("invalid message type for sync of master assignments: ",
+                     messageType);
         }
 
         galois::gDebug("[", base_DistGraph::id, "] host ", sendingHost,

--- a/libgalois/include/galois/graphs/FileGraph.h
+++ b/libgalois/include/galois/graphs/FileGraph.h
@@ -327,7 +327,7 @@ public:
                 internal::EdgeSortCompWrapper<EdgeSortValue<GraphNode, EdgeTy>,
                                               CompTy>(comp));
     } else {
-      GALOIS_DIE("unknown file version at sortEdgesByEdgeData", graphVersion);
+      GALOIS_DIE("unknown file version: ", graphVersion);
     }
   }
 
@@ -372,7 +372,7 @@ public:
           &edgeDst, &ed);
       std::sort(begin, end, comp);
     } else {
-      GALOIS_DIE("unknown file version at sortEdgesByEdgeData", graphVersion);
+      GALOIS_DIE("unknown file version: ", graphVersion);
     }
   }
 

--- a/libgalois/include/galois/graphs/LC_CSR_Graph.h
+++ b/libgalois/include/galois/graphs/LC_CSR_Graph.h
@@ -907,7 +907,7 @@ public:
   void readGraphFromGRFile(const std::string& filename) {
     std::ifstream graphFile(filename.c_str());
     if (!graphFile.is_open()) {
-      GALOIS_DIE("ERROR: Failed to open file.");
+      GALOIS_DIE("failed to open file");
     }
     uint64_t header[4];
     graphFile.read(reinterpret_cast<char*>(header), sizeof(uint64_t) * 4);
@@ -923,7 +923,7 @@ public:
      **/
     assert(edgeIndData.data());
     if (!edgeIndData.data()) {
-      GALOIS_DIE("Failed: memory not allocated for edgeIndData.");
+      GALOIS_DIE("out of memory");
     }
 
     // start position to read index data
@@ -936,7 +936,7 @@ public:
      **/
     assert(edgeDst.data());
     if (!edgeDst.data()) {
-      GALOIS_DIE("Failed: memory not allocated for edgeDst.");
+      GALOIS_DIE("out of memory");
     }
 
     readPosition = ((4 + numNodes) * sizeof(uint64_t));
@@ -959,14 +959,14 @@ public:
         readPosition += sizeof(uint64_t);
       }
     } else {
-      GALOIS_DIE("ERROR: Unknown graph file version.");
+      GALOIS_DIE("unknown file version: ", version);
     }
     /**
      * Load edge data array
      **/
     assert(edgeData.data());
     if (!edgeData.data()) {
-      GALOIS_DIE("Failed: memory not allocated for edgeData.");
+      GALOIS_DIE("out of memory");
     }
     graphFile.seekg(readPosition);
     graphFile.read(reinterpret_cast<char*>(edgeData.data()),
@@ -989,7 +989,7 @@ public:
   void readGraphFromGRFile(const std::string& filename) {
     std::ifstream graphFile(filename.c_str());
     if (!graphFile.is_open()) {
-      GALOIS_DIE("ERROR: Failed to open file.");
+      GALOIS_DIE("failed to open file");
     }
     uint64_t header[4];
     graphFile.read(reinterpret_cast<char*>(header), sizeof(uint64_t) * 4);
@@ -1005,7 +1005,7 @@ public:
      **/
     assert(edgeIndData.data());
     if (!edgeIndData.data()) {
-      GALOIS_DIE("Failed: memory not allocated for edgeIndData.");
+      GALOIS_DIE("out of memory");
     }
     // start position to read index data
     uint64_t readPosition = (4 * sizeof(uint64_t));
@@ -1017,7 +1017,7 @@ public:
      **/
     assert(edgeDst.data());
     if (!edgeDst.data()) {
-      GALOIS_DIE("Failed: memory not allocated for edgeDst.");
+      GALOIS_DIE("out of memory");
     }
     readPosition = ((4 + numNodes) * sizeof(uint64_t));
     graphFile.seekg(readPosition);
@@ -1028,7 +1028,7 @@ public:
       graphFile.read(reinterpret_cast<char*>(edgeDst.data()),
                      sizeof(uint64_t) * numEdges);
     } else {
-      GALOIS_DIE("ERROR: Unknown graph file version.");
+      GALOIS_DIE("unknown file version: ", version);
     }
 
     initializeLocalRanges();

--- a/libgalois/include/galois/runtime/Executor_Deterministic.h
+++ b/libgalois/include/galois/runtime/Executor_Deterministic.h
@@ -196,7 +196,7 @@ public:
   bool propagate() { return this->find()->isReady(); }
 
   virtual void alwaysAcquire(Lockable*, galois::MethodFlag) {
-    GALOIS_DIE("shouldn't reach here");
+    GALOIS_DIE("unreachable");
   }
 };
 
@@ -1593,7 +1593,7 @@ bool Executor<OptionsTy>::executeTask(ThreadLocalData& tld, Context* ctx) {
     return false;
     break;
   default:
-    GALOIS_DIE("Unknown conflict flag");
+    GALOIS_DIE("unknown conflict flag");
     break;
   }
 
@@ -1605,7 +1605,7 @@ bool Executor<OptionsTy>::executeTask(ThreadLocalData& tld, Context* ctx) {
     for (auto& item : tld.facing.getPushBuffer()) {
       this->pushNew(item, parent, ++count);
       if (count == 0) {
-        GALOIS_DIE("Counter overflow");
+        GALOIS_DIE("counter overflow");
       }
     }
     if (count)

--- a/libgalois/include/galois/runtime/Profile.h
+++ b/libgalois/include/galois/runtime/Profile.h
@@ -84,11 +84,12 @@ void papiInit() {
   int retval = PAPI_library_init(PAPI_VER_CURRENT);
 
   if (retval != PAPI_VER_CURRENT && retval > 0) {
-    GALOIS_DIE("PAPI library version mismatch!");
+    GALOIS_DIE("PAPI library version mismatch: ", retval,
+               " != ", PAPI_VER_CURRENT);
   }
 
   if (retval < 0) {
-    GALOIS_DIE("Initialization error!");
+    GALOIS_DIE("initialization error!");
   }
 
   if ((retval = PAPI_thread_init(&papiGetTID)) != PAPI_OK) {
@@ -102,7 +103,7 @@ void decodePapiEvents(const V1& eventNames, V2& papiEvents) {
     char buf[256];
     std::strcpy(buf, eventNames[i].c_str());
     if (PAPI_event_name_to_code(buf, &papiEvents[i]) != PAPI_OK) {
-      GALOIS_DIE("Failed to recognize eventName = ", eventNames[i],
+      GALOIS_DIE("failed to recognize eventName = ", eventNames[i],
                  ", event code: ", papiEvents[i]);
     }
   }
@@ -112,7 +113,7 @@ template <typename V1, typename V2, typename V3>
 void papiStart(V1& eventSets, V2& papiResults, V3& papiEvents) {
   galois::on_each([&](const unsigned tid, const unsigned numT) {
     if (PAPI_register_thread() != PAPI_OK) {
-      GALOIS_DIE("Failed to register thread with PAPI");
+      GALOIS_DIE("failed to register thread with PAPI");
     }
 
     int& eventSet = *eventSets.getLocal();
@@ -121,11 +122,11 @@ void papiStart(V1& eventSets, V2& papiResults, V3& papiEvents) {
     papiResults.getLocal()->resize(papiEvents.size());
 
     if (PAPI_create_eventset(&eventSet) != PAPI_OK) {
-      GALOIS_DIE("Failed to init event set");
+      GALOIS_DIE("failed to init event set");
     }
     if (PAPI_add_events(eventSet, papiEvents.data(), papiEvents.size()) !=
         PAPI_OK) {
-      GALOIS_DIE("Failed to add events");
+      GALOIS_DIE("failed to add events");
     }
 
     if (PAPI_start(eventSet) != PAPI_OK) {
@@ -160,7 +161,7 @@ void papiStop(V1& eventSets, V2& papiResults, V3& eventNames,
     }
 
     if (PAPI_unregister_thread() != PAPI_OK) {
-      GALOIS_DIE("Failed to un-register thread with PAPI");
+      GALOIS_DIE("failed to un-register thread with PAPI");
     }
   });
 }

--- a/libgalois/include/galois/runtime/Statistics.h
+++ b/libgalois/include/galois/runtime/Statistics.h
@@ -280,7 +280,7 @@ struct VecStat : public VecStat_with_MinMaxSum<T> {
       return Base::avg();
 
     default:
-      GALOIS_DIE("Shouldn't reach this point");
+      GALOIS_DIE("unreachable");
     }
   }
 };
@@ -305,7 +305,7 @@ struct VecStat<gstl::Str> : public AggregStat<gstl::Str>::with_mem {
       return Base::values()[0];
 
     default:
-      GALOIS_DIE("Shouldn't reach this point. m_totalTy has unsupported value");
+      GALOIS_DIE("unreachable");
     }
   }
 };

--- a/libgalois/src/Barrier_Pthread.cpp
+++ b/libgalois/src/Barrier_Pthread.cpp
@@ -38,31 +38,35 @@ class PthreadBarrier : public galois::substrate::Barrier {
 
 public:
   PthreadBarrier() {
-    if (pthread_barrier_init(&bar, 0, ~0))
-      GALOIS_DIE("PTHREAD");
+    int err = 0;
+    if ((err = pthread_barrier_init(&bar, 0, ~0)))
+      GALOIS_DIE("pthread ", err);
   }
 
   PthreadBarrier(unsigned int v) {
-    if (pthread_barrier_init(&bar, 0, v))
-      GALOIS_DIE("PTHREAD");
+    int err = 0;
+    if ((err = pthread_barrier_init(&bar, 0, v)))
+      GALOIS_DIE("pthread ", err);
   }
 
   virtual ~PthreadBarrier() {
-    if (pthread_barrier_destroy(&bar))
-      GALOIS_DIE("PTHREAD");
+    int err = 0;
+    if ((err = pthread_barrier_destroy(&bar)))
+      GALOIS_DIE("pthread ", err);
   }
 
   virtual void reinit(unsigned val) {
-    if (pthread_barrier_destroy(&bar))
-      GALOIS_DIE("PTHREAD");
-    if (pthread_barrier_init(&bar, 0, val))
-      GALOIS_DIE("PTHREAD");
+    int err = 0;
+    if ((err = pthread_barrier_destroy(&bar)))
+      GALOIS_DIE("pthread ", err);
+    if ((err = pthread_barrier_init(&bar, 0, val)))
+      GALOIS_DIE("pthread ", err);
   }
 
   virtual void wait() {
     int rc = pthread_barrier_wait(&bar);
     if (rc && rc != PTHREAD_BARRIER_SERIAL_THREAD)
-      GALOIS_DIE("PTHREAD");
+      GALOIS_DIE("pthread ", rc);
   }
 
   virtual const char* name() const { return "PthreadBarrier"; }

--- a/libgalois/src/Context.cpp
+++ b/libgalois/src/Context.cpp
@@ -95,5 +95,5 @@ unsigned galois::runtime::SimpleRuntimeContext::cancelIteration() {
 
 void galois::runtime::SimpleRuntimeContext::subAcquire(
     galois::runtime::Lockable*, galois::MethodFlag) {
-  GALOIS_DIE("Shouldn't get here");
+  GALOIS_DIE("unreachable");
 }

--- a/libgalois/src/FileGraph.cpp
+++ b/libgalois/src/FileGraph.cpp
@@ -196,7 +196,7 @@ static size_t rawBlockSize(size_t numNodes, size_t numEdges,
     bytes += sizeof(uint64_t) * numEdges;
     // no padding necessary in version 2 TODO verify this
   } else {
-    GALOIS_DIE("graph version not set", graphVersion);
+    GALOIS_DIE("unknown file version: ", graphVersion);
   }
 
   bytes += sizeofEdgeData * numEdges;
@@ -231,7 +231,7 @@ void* FileGraph::fromArrays(uint64_t* out_idx, uint64_t num_nodes, void* outs,
   } else if (oGraphVersion == 2) {
     *fptr++ = convert_htole64(2);
   } else {
-    GALOIS_DIE("unknown file version to fromArrays", oGraphVersion);
+    GALOIS_DIE("unknown file version: ", oGraphVersion);
   }
   *fptr++ = convert_htole64(sizeof_edge_data);
   *fptr++ = convert_htole64(num_nodes);
@@ -409,7 +409,7 @@ void FileGraph::partFromFile(const std::string& filename, NodeRange nrange,
              edgeOffset * sizeof(uint64_t);
     outs = loadFromOffset(fd, offset, length, mappings);
   } else {
-    GALOIS_DIE("unknown file version at partFromFile", graphVersion);
+    GALOIS_DIE("unknown file version: ", graphVersion);
   }
 
   edgeData = 0;
@@ -553,7 +553,7 @@ uint64_t FileGraph::getEdgeIdx(GraphNode src, GraphNode dst) {
 
     return ~static_cast<uint64_t>(0);
   } else {
-    GALOIS_DIE("unknown file version at getEdgeIdx", graphVersion);
+    GALOIS_DIE("unknown file version: ", graphVersion);
   }
 }
 
@@ -620,7 +620,7 @@ void* FileGraph::raw_neighbor_begin(GraphNode N) {
   } else if (graphVersion == 2) {
     return &(((uint64_t*)outs)[*edge_begin(N)]);
   } else {
-    GALOIS_DIE("unknown file version at raw_neighbor_begin", graphVersion);
+    GALOIS_DIE("unknown file version: ", graphVersion);
   }
 
   return nullptr;
@@ -632,7 +632,7 @@ void* FileGraph::raw_neighbor_end(GraphNode N) {
   } else if (graphVersion == 2) {
     return &(((uint64_t*)outs)[*edge_end(N)]);
   } else {
-    GALOIS_DIE("unknown file version at raw_neighbor_end", graphVersion);
+    GALOIS_DIE("unknown file version: ", graphVersion);
   }
 
   return nullptr;
@@ -675,7 +675,7 @@ FileGraph::GraphNode FileGraph::getEdgeDst(edge_iterator it) {
     numBytesReadEdgeDst += 8;
     return convert_le64toh(((uint64_t*)outs)[*it]);
   } else {
-    GALOIS_DIE("unknown file version at getEdgeDst", graphVersion);
+    GALOIS_DIE("unknown file version: ", graphVersion);
   }
 
   return -1;

--- a/libgalois/src/PerThreadStorage.cpp
+++ b/libgalois/src/PerThreadStorage.cpp
@@ -43,7 +43,7 @@ inline void* alloc() {
   // alloc a single page, don't prefault
   void* toReturn = galois::substrate::allocPages(1, true);
   if (toReturn == nullptr) {
-    GALOIS_DIE("Out of memory in per thread storage allocation");
+    GALOIS_DIE("per-thread storage out of memory");
   }
   return toReturn;
 }
@@ -100,7 +100,7 @@ unsigned galois::substrate::PerBackend::allocOffset(const unsigned sz) {
     ;
 
   if (index == MAX_SIZE) {
-    GALOIS_DIE("PTS out of memory");
+    GALOIS_DIE("per-thread storage out of memory");
     return ptAllocSize;
   }
 

--- a/libgalois/src/Statistics.cpp
+++ b/libgalois/src/Statistics.cpp
@@ -49,7 +49,7 @@ void galois::runtime::reportRUsage(const std::string& id) {
   struct rusage usage_stats;
   int rusage_result = getrusage(RUSAGE_SELF, &usage_stats);
   if (rusage_result != 0) {
-    GALOIS_DIE("getrusage failed to execute cleanly");
+    GALOIS_DIE("getrusage failed: ", rusage_result);
   }
 
   // report stats using ID to identify them

--- a/libgluon/include/galois/graphs/GluonEdgeSubstrate.h
+++ b/libgluon/include/galois/graphs/GluonEdgeSubstrate.h
@@ -310,11 +310,11 @@ private:
     int taskRank;
     MPI_Comm_rank(MPI_COMM_WORLD, &taskRank);
     if ((unsigned)taskRank != id)
-      GALOIS_DIE("Mismatch in MPI rank");
+      GALOIS_DIE("mismatch in MPI rank");
     int numTasks;
     MPI_Comm_size(MPI_COMM_WORLD, &numTasks);
     if ((unsigned)numTasks != numHosts)
-      GALOIS_DIE("Mismatch in MPI rank");
+      GALOIS_DIE("mismatch in MPI rank");
 #endif
     // group setup
     MPI_Group world_group;
@@ -336,7 +336,7 @@ private:
         break;
       case noBareMPI:
       default:
-        GALOIS_DIE("Unsupported bare MPI");
+        GALOIS_DIE("unsupported bare MPI");
       }
     }
 #endif
@@ -593,8 +593,7 @@ private:
   template <SyncType syncType>
   void convertGIDToLID(const std::string& loopName,
                        galois::PODResizeableArray<unsigned int>& offsets) {
-    galois::gWarn("WARNING: convert GID to LID used in sync call (not "
-                  "optimized)");
+    galois::gWarn("convert GID to LID used in sync call (not optimized)");
     std::string syncTypeStr = (syncType == syncReduce) ? "Reduce" : "Broadcast";
     std::string doall_str(syncTypeStr + "_GID2LID_" +
                           get_run_identifier(loopName));
@@ -1157,19 +1156,6 @@ private:
       if (async) {
         FnTy::reduce(lid, userGraph.getEdgeData(lid), val);
       } else {
-        // uint64_t edgeSource =
-        // userGraph.getGID(userGraph.findSourceFromEdge(lid)); if (val !=
-        // userGraph.getHostID(edgeSource)) {
-        //  GALOIS_DIE(galois::runtime::getSystemNetworkInterface().ID, " ",
-        //  edgeSource, " ", val, " ", userGraph.getHostID(edgeSource));
-
-        //  assert(val == userGraph.getHostID(edgeSource));
-        //}
-
-        // galois::gPrint("[", galois::runtime::getSystemNetworkInterface().ID ,
-        //               "] broadcast, val is ", val, " edge srouce ",
-        //               userGraph.getGID(userGraph.findSourceFromEdge(lid)),
-        //               "\n");
         FnTy::setVal(lid, userGraph.getEdgeData(lid), val);
         assert(FnTy::extract(lid, userGraph.getEdgeData(lid)) == val);
       }
@@ -2201,7 +2187,7 @@ private:
       syncOnesidedMPI<syncReduce, ReduceFnTy, BitsetFnTy>(loopName);
       break;
     default:
-      GALOIS_DIE("Unsupported bare MPI");
+      GALOIS_DIE("unsupported bare MPI");
     }
 #endif
 
@@ -2248,7 +2234,7 @@ private:
                                                                 use_bitset);
       break;
     default:
-      GALOIS_DIE("Unsupported bare MPI");
+      GALOIS_DIE("unsupported bare MPI");
     }
 #endif
 

--- a/libgluon/include/galois/graphs/GluonSubstrate.h
+++ b/libgluon/include/galois/graphs/GluonSubstrate.h
@@ -370,11 +370,11 @@ private:
     int taskRank;
     MPI_Comm_rank(MPI_COMM_WORLD, &taskRank);
     if ((unsigned)taskRank != id)
-      GALOIS_DIE("Mismatch in MPI rank");
+      GALOIS_DIE("mismatch in MPI rank");
     int numTasks;
     MPI_Comm_size(MPI_COMM_WORLD, &numTasks);
     if ((unsigned)numTasks != numHosts)
-      GALOIS_DIE("Mismatch in MPI rank");
+      GALOIS_DIE("mismatch in MPI rank");
 #endif
     // group setup
     MPI_Group world_group;
@@ -396,7 +396,7 @@ private:
         break;
       case noBareMPI:
       default:
-        GALOIS_DIE("Unsupported bare MPI");
+        GALOIS_DIE("unsupported bare MPI");
       }
     }
 #endif
@@ -890,7 +890,7 @@ private:
           return ((gridRowID() != gridRowID(host)) &&
                   (gridColumnID() != gridColumnID(host))); // false
         default:
-          GALOIS_DIE("isNotCommPartnerCVC error");
+          GALOIS_DIE("unreachable");
         }
       } else { // syncBroadcast
         switch (readLocation) {
@@ -904,7 +904,7 @@ private:
           return ((gridRowID() != gridRowID(host)) &&
                   (gridColumnID() != gridColumnID(host))); // false
         default:
-          GALOIS_DIE("isNotCommPartnerCVC error");
+          GALOIS_DIE("unreachable");
         }
       }
     } else {
@@ -920,7 +920,7 @@ private:
           return ((gridRowID() != gridRowID(host)) &&
                   (gridColumnID() != gridColumnID(host))); // false
         default:
-          GALOIS_DIE("isNotCommPartnerCVC error");
+          GALOIS_DIE("unreachable");
         }
       } else { // syncBroadcast, 1
         switch (readLocation) {
@@ -934,7 +934,7 @@ private:
           return ((gridRowID() != gridRowID(host)) &&
                   (gridColumnID() != gridColumnID(host))); // false
         default:
-          GALOIS_DIE("isNotCommPartnerCVC error");
+          GALOIS_DIE("unreachable");
         }
       }
       return false;
@@ -2740,7 +2740,7 @@ private:
                       BitsetFnTy>(loopName);
       break;
     default:
-      GALOIS_DIE("Unsupported bare MPI");
+      GALOIS_DIE("unsupported bare MPI");
     }
 #endif
 
@@ -2819,7 +2819,7 @@ private:
                       BitsetFnTy>(loopName, use_bitset);
       break;
     default:
-      GALOIS_DIE("Unsupported bare MPI");
+      GALOIS_DIE("unsupported bare MPI");
     }
 #endif
 
@@ -3085,7 +3085,7 @@ private:
     // note this call function signature is diff. from specialized versions:
     // will cause compile time error if this struct is used (which is what
     // we want)
-    void call() { GALOIS_DIE("Invalid read location for sync on demand"); }
+    void call() { GALOIS_DIE("invalid read location for sync on demand"); }
   };
 
   /**
@@ -3203,7 +3203,7 @@ private:
               substrate->sync_src_to_src<SyncFnTy, BitsetFnTy>(loopName);
               substrate->sync_src_to_dst<SyncFnTy, BitsetFnTy>(loopName);
             } else {
-              GALOIS_DIE("Invalid bitvector flag setting in syncOnDemand");
+              GALOIS_DIE("invalid bitvector flag setting in syncOnDemand");
             }
           } else if (fieldFlags.src_to_src()) {
             substrate->sync_src_to_src<SyncFnTy, BitsetFnTy>(loopName);
@@ -3221,7 +3221,7 @@ private:
               substrate->sync_dst_to_src<SyncFnTy, BitsetFnTy>(loopName);
               substrate->sync_dst_to_dst<SyncFnTy, BitsetFnTy>(loopName);
             } else {
-              GALOIS_DIE("Invalid bitvector flag setting in syncOnDemand");
+              GALOIS_DIE("invalid bitvector flag setting in syncOnDemand");
             }
           } else if (fieldFlags.dst_to_src()) {
             substrate->sync_dst_to_src<SyncFnTy, BitsetFnTy>(loopName);
@@ -3250,7 +3250,7 @@ private:
             substrate->sync_any_to_src<SyncFnTy, BitsetFnTy>(loopName);
             substrate->sync_any_to_dst<SyncFnTy, BitsetFnTy>(loopName);
           } else {
-            GALOIS_DIE("Invalid bitvector flag setting in syncOnDemand");
+            GALOIS_DIE("invalid bitvector flag setting in syncOnDemand");
           }
         } else if (src_read) {
           substrate->sync_any_to_src<SyncFnTy, BitsetFnTy>(loopName);

--- a/libgluon/include/galois/runtime/SyncStructures.h
+++ b/libgluon/include/galois/runtime/SyncStructures.h
@@ -1890,7 +1890,7 @@ public:
                                                                                \
     static void setVal(uint32_t GALOIS_UNUSED(node_id),                        \
                        struct NodeData& GALOIS_UNUSED(node), ValTy y) {        \
-      GALOIS_DIE("Execution shouldn't get here; needs index arg\n");           \
+      GALOIS_DIE("execution shouldn't get here; needs index arg");             \
     }                                                                          \
                                                                                \
     static bool setVal_batch(unsigned uint8_t*, DataCommMode) {                \

--- a/lonestar/analytics/cpu/bfs/bfs.cpp
+++ b/lonestar/analytics/cpu/bfs/bfs.cpp
@@ -418,7 +418,7 @@ int main(int argc, char** argv) {
     if (BFS::verify(graph, source)) {
       std::cout << "Verification successful.\n";
     } else {
-      GALOIS_DIE("Verification failed");
+      GALOIS_DIE("verification failed");
     }
   }
 

--- a/lonestar/analytics/cpu/kcore/kcore.cpp
+++ b/lonestar/analytics/cpu/kcore/kcore.cpp
@@ -235,8 +235,9 @@ int main(int argc, char** argv) {
   LonestarStart(argc, argv, name, desc, url);
 
   if (!symmetricGraph) {
-    GALOIS_DIE("User did not pass in symmetric graph flag signifying they are "
-               "aware this program needs to be passed a symmetric graph.");
+    GALOIS_DIE("kcore requires a symmetric graph input;"
+               " please use the -symmetricGraph flag "
+               " to indicate the input is a symmetric graph");
   }
 
   //! Some initial stat reporting.
@@ -287,7 +288,7 @@ int main(int argc, char** argv) {
     //! Synchronous k-core.
     syncCascadeKCore(graph);
   } else {
-    GALOIS_DIE("Invalid specification of k-core algorithm");
+    GALOIS_DIE("invalid specification of k-core algorithm");
   }
 
   runtimeTimer.stop();

--- a/lonestar/analytics/cpu/ktruss/K-Truss.cpp
+++ b/lonestar/analytics/cpu/ktruss/K-Truss.cpp
@@ -663,8 +663,9 @@ int main(int argc, char** argv) {
   LonestarStart(argc, argv, name, desc, url);
 
   if (!symmetricGraph) {
-    GALOIS_DIE("User did not pass in symmetric graph flag signifying they are "
-               "aware this program needs to be passed a symmetric graph.");
+    GALOIS_DIE("k-truss requires a symmetric graph input;"
+               " please use the -symmetricGraph flag "
+               " to indicate the input is a symmetric graph");
   }
 
   if (2 > trussNum) {

--- a/lonestar/analytics/cpu/ktruss/Verify.cpp
+++ b/lonestar/analytics/cpu/ktruss/Verify.cpp
@@ -119,13 +119,13 @@ void readTruss(Graph& g) {
   if (ktrussEdges && edges != ktrussEdges) {
     std::cerr << "edges read not equal to -trussEdges=" << ktrussEdges
               << std::endl;
-    GALOIS_DIE("Verification error");
+    GALOIS_DIE("verification error");
   }
 
   if (ktrussNodes && nodes.size() != ktrussNodes) {
     std::cerr << "nodes read not equal to -trussNodes=" << ktrussNodes
               << std::endl;
-    GALOIS_DIE("Verification error");
+    GALOIS_DIE("verification error");
   }
 }
 

--- a/lonestar/analytics/cpu/matching/bipartite-mcm.cpp
+++ b/lonestar/analytics/cpu/matching/bipartite-mcm.cpp
@@ -1155,7 +1155,7 @@ void start(int N, int numEdges, int numGroups) {
       typename GraphTypes<G>::Matching matching;
       PrepareForVerifier<G, Algo>()(g, &matching);
       if (!Verifier<G>()(g, matching)) {
-        GALOIS_DIE("Verification failed");
+        GALOIS_DIE("verification failed");
       } else {
         std::cout << "Verification successful.\n";
       }

--- a/lonestar/analytics/cpu/matrixcompletion/matrixCompletion.cpp
+++ b/lonestar/analytics/cpu/matrixcompletion/matrixCompletion.cpp
@@ -159,7 +159,7 @@ template <typename Graph>
 void verify(Graph& g, const std::string& prefix) {
   std::cout << countEdges(g) << " : " << g.sizeEdges() << "\n";
   if (countEdges(g) != g.sizeEdges()) {
-    GALOIS_DIE("Error: edge list of input graph probably not sorted");
+    GALOIS_DIE("edge list of input graph probably not sorted");
   }
 
   double error = sumSquaredError(g);
@@ -1479,7 +1479,7 @@ void run() {
       writeAsciiLatentVectors(g, outputFilename);
       break;
     default:
-      GALOIS_DIE("Invalid output type for latent vector output");
+      GALOIS_DIE("invalid output type for latent vector output");
     }
   }
 

--- a/lonestar/analytics/cpu/sssp/SSSP.cpp
+++ b/lonestar/analytics/cpu/sssp/SSSP.cpp
@@ -486,7 +486,7 @@ int main(int argc, char** argv) {
     if (SSSP::verify(graph, source)) {
       std::cout << "Verification successful.\n";
     } else {
-      GALOIS_DIE("Verification failed");
+      GALOIS_DIE("verification failed");
     }
   }
 

--- a/lonestar/analytics/distributed/bc/bc_mr.cpp
+++ b/lonestar/analytics/distributed/bc/bc_mr.cpp
@@ -602,8 +602,7 @@ int main(int argc, char** argv) {
   }
 
   if (startNode && !sourceVector.empty()) {
-    GALOIS_DIE("Should not use startNode cmd-line option with specified "
-               "sources");
+    GALOIS_DIE("startNode option not compatible with sourcesToUse");
   }
 
   // "sourceVector" if file not provided

--- a/lonestar/libdistbench/include/DistBench/Input.h
+++ b/lonestar/libdistbench/include/DistBench/Input.h
@@ -82,7 +82,7 @@ inline const char* EnumToString(PARTITIONING_SCHEME e) {
   case SUGAR_O:
     return "sugar-oec";
   default:
-    GALOIS_DIE("Unsupported partition");
+    GALOIS_DIE("unsupported partition scheme: ", e);
   }
 }
 
@@ -130,8 +130,9 @@ template <typename NodeData, typename EdgeData>
 galois::graphs::DistGraph<NodeData, EdgeData>*
 constructSymmetricGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
   if (!inputFileSymmetric) {
-    GALOIS_DIE("Calling constructSymmetricGraph without inputFileSymmetric "
-               "flag");
+    GALOIS_DIE("application requires a symmetric graph input;"
+               " please use the -symmetricGraph flag "
+               " to indicate the input is a symmetric graph");
   }
 
   switch (partitionScheme) {
@@ -173,7 +174,7 @@ constructSymmetricGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
         inputFile, galois::CUSP_CSR, galois::CUSP_CSR, true,
         inputFileTranspose);
   default:
-    GALOIS_DIE("Error: partition scheme specified is invalid");
+    GALOIS_DIE("partition scheme specified is invalid: ", partitionScheme);
     return nullptr;
   }
 }
@@ -214,8 +215,7 @@ constructGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSR, false,
           inputFileTranspose, mastersFile);
     } else {
-      GALOIS_DIE("Error: attempting incoming edge cut without transpose "
-                 "graph");
+      GALOIS_DIE("incoming edge cut requires transpose graph");
       break;
     }
 
@@ -229,8 +229,7 @@ constructGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSR, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: attempting incoming hybrid cut without transpose "
-                 "graph");
+      GALOIS_DIE("incoming hybrid cut requires transpose graph");
       break;
     }
 
@@ -245,8 +244,7 @@ constructGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSR, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: attempting cvc incoming cut without "
-                 "transpose graph");
+      GALOIS_DIE("cvc incoming cut requires transpose graph");
       break;
     }
 
@@ -264,7 +262,7 @@ constructGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSR, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: attempting Ginger without transpose graph");
+      GALOIS_DIE("Ginger requires transpose graph");
       break;
     }
 
@@ -278,7 +276,7 @@ constructGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSR, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: attempting Fennel incoming without transpose graph");
+      GALOIS_DIE("Fennel requires transpose graph");
       break;
     }
 
@@ -288,7 +286,7 @@ constructGraph(std::vector<unsigned>& GALOIS_UNUSED(scaleFactor)) {
         inputFileTranspose);
 
   default:
-    GALOIS_DIE("Error: partition scheme specified is invalid");
+    GALOIS_DIE("partition scheme specified is invalid: ", partitionScheme);
     return nullptr;
   }
 }
@@ -341,8 +339,7 @@ constructGraph(std::vector<unsigned>&) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSC, false,
           inputFileTranspose, mastersFile);
     } else {
-      GALOIS_DIE("Error: attempting incoming edge cut without transpose "
-                 "graph");
+      GALOIS_DIE("iec requires transpose graph");
       break;
     }
 
@@ -356,7 +353,7 @@ constructGraph(std::vector<unsigned>&) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSC, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: (hivc) iterate over in-edges without transpose graph");
+      GALOIS_DIE("hivc requires transpose graph");
       break;
     }
 
@@ -371,7 +368,7 @@ constructGraph(std::vector<unsigned>&) {
                                                   galois::CUSP_CSC, false,
                                                   inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: (cvc) iterate over in-edges without transpose graph");
+      GALOIS_DIE("cvc requires transpose graph");
       break;
     }
 
@@ -385,7 +382,7 @@ constructGraph(std::vector<unsigned>&) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSC, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: attempting Ginger without transpose graph");
+      GALOIS_DIE("Ginger requires transpose graph");
       break;
     }
 
@@ -399,7 +396,7 @@ constructGraph(std::vector<unsigned>&) {
           inputFile, galois::CUSP_CSC, galois::CUSP_CSC, false,
           inputFileTranspose);
     } else {
-      GALOIS_DIE("Error: attempting Fennel incoming without transpose graph");
+      GALOIS_DIE("Fennel requires transpose graph");
       break;
     }
 
@@ -409,7 +406,7 @@ constructGraph(std::vector<unsigned>&) {
         inputFileTranspose);
 
   default:
-    GALOIS_DIE("Error: partition scheme specified is invalid");
+    GALOIS_DIE("partition scheme specified is invalid: ", partitionScheme);
     return nullptr;
   }
 }

--- a/lonestar/libdistbench/include/DistBench/MiningStart.h
+++ b/lonestar/libdistbench/include/DistBench/MiningStart.h
@@ -107,7 +107,7 @@ static void marshalGPUGraph(
     *cuda_ctx = get_CUDA_context(my_host_id);
 
     if (!init_CUDA_context(*cuda_ctx, gpudevice)) {
-      GALOIS_DIE("Failed to initialize CUDA context");
+      GALOIS_DIE("failed to initialize CUDA context");
     }
 
     EdgeMarshalGraph m;

--- a/lonestar/libdistbench/include/DistBench/Start.h
+++ b/lonestar/libdistbench/include/DistBench/Start.h
@@ -105,7 +105,7 @@ static void marshalGPUGraph(
     *cuda_ctx = get_CUDA_context(my_host_id);
 
     if (!init_CUDA_context(*cuda_ctx, gpudevice)) {
-      GALOIS_DIE("Failed to initialize CUDA context");
+      GALOIS_DIE("failed to initialize CUDA context");
     }
 
     MarshalGraph m;
@@ -179,8 +179,9 @@ loadSymmetricDistGraph(std::vector<unsigned>& scaleFactor) {
   if (inputFileSymmetric) {
     loadedGraph = constructSymmetricGraph<NodeData, EdgeData>(scaleFactor);
   } else {
-    GALOIS_DIE("must use -symmetricGraph flag with a symmetric graph for "
-               "this benchmark");
+    GALOIS_DIE("application requires a symmetric graph input;"
+               " please use the -symmetricGraph flag "
+               " to indicate the input is a symmetric graph");
   }
 
   assert(loadedGraph != nullptr);

--- a/lonestar/scientific/cpu/delaunayrefinement/DelaunayRefinement.cpp
+++ b/lonestar/scientific/cpu/delaunayrefinement/DelaunayRefinement.cpp
@@ -200,11 +200,11 @@ int main(int argc, char** argv) {
     int size = galois::ParallelSTL::count_if(graph.begin(), graph.end(),
                                              is_bad(graph));
     if (size != 0) {
-      GALOIS_DIE("Bad triangles remaining");
+      GALOIS_DIE("bad triangles remaining");
     }
     Verifier v;
     if (!v.verify(graph)) {
-      GALOIS_DIE("Refinement failed");
+      GALOIS_DIE("refinement failed");
     }
     std::cout << std::distance(graph.begin(), graph.end())
               << " total triangles\n";

--- a/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulation.cpp
+++ b/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulation.cpp
@@ -312,7 +312,7 @@ public:
   void from(const std::string& name) {
     std::ifstream scanner(name.c_str());
     if (!scanner.good()) {
-      GALOIS_DIE("Could not open file: ", name);
+      GALOIS_DIE("could not open file: ", name);
     }
     if (name.find(".node") == name.size() - 5) {
       fromTriangle(scanner);
@@ -324,7 +324,7 @@ public:
     if (points.size())
       addBoundaryPoints();
     else {
-      GALOIS_DIE("No points found in file: ", name);
+      GALOIS_DIE("no points found in file: ", name);
     }
   }
 };
@@ -535,7 +535,7 @@ int main(int argc, char** argv) {
   if (!skipVerify) {
     Verifier verifier;
     if (!verifier.verify(&graph)) {
-      GALOIS_DIE("Triangulation failed");
+      GALOIS_DIE("triangulation failed");
     }
     std::cout << "Triangulation OK\n";
   }

--- a/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulationDet.cpp
+++ b/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulationDet.cpp
@@ -166,7 +166,7 @@ public:
   void from(const std::string& name) {
     std::ifstream scanner(name.c_str());
     if (!scanner.good()) {
-      GALOIS_DIE("Could not open file: ", name);
+      GALOIS_DIE("could not open file: ", name);
     }
     if (name.find(".node") == name.size() - 5) {
       fromTriangle(scanner);
@@ -178,7 +178,7 @@ public:
     if (points.size())
       addBoundaryPoints();
     else {
-      GALOIS_DIE("No points found in file: ", name);
+      GALOIS_DIE("no points found in file: ", name);
     }
   }
 };
@@ -700,7 +700,7 @@ static void run(Rounds& rounds, Graph& graph) {
       dt.generateMesh<detDisjoint, DWL>(pptrs);
       break;
     default:
-      GALOIS_DIE("Unknown algorithm: ", detAlgo);
+      GALOIS_DIE("unknown algorithm: ", detAlgo);
     }
 
     PT.stop();
@@ -768,7 +768,7 @@ int main(int argc, char** argv) {
   if (!skipVerify) {
     Verifier verifier;
     if (!verifier.verify(&graph)) {
-      GALOIS_DIE("Triangulation failed");
+      GALOIS_DIE("triangulation failed");
     }
     std::cout << "Triangulation OK\n";
   }

--- a/tools/dist-graph-convert/dist-graph-convert-helpers.cpp
+++ b/tools/dist-graph-convert/dist-graph-convert-helpers.cpp
@@ -111,8 +111,8 @@ uint32_t findOwner(const uint64_t gID,
     } else if (gID >= currentPair.second) { // gid >= currentPair.second
       // MOVE UP
       lb = mid + 1;
-    } else { // die; we should fall into one of the above cases
-      GALOIS_DIE("Issue in findOwner in dist-graph-convert helpers.");
+    } else {
+      GALOIS_DIE("unreachable");
     }
   }
 

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -652,7 +652,7 @@ struct Mtx2Gr : public HasNoVoidSpecialization {
     for (int phase = 0; phase < 2; ++phase) {
       std::ifstream infile(infilename.c_str());
       if (!infile) {
-        GALOIS_DIE("Failed to open input file");
+        GALOIS_DIE("failed to open input file");
       }
 
       // Skip comments
@@ -676,7 +676,7 @@ struct Mtx2Gr : public HasNoVoidSpecialization {
         }
       }
       if (tokens.size() != 3) {
-        GALOIS_DIE("Unknown problem specification line: ", line.str());
+        GALOIS_DIE("unknown problem specification line: ", line.str());
       }
       // Prefer C functions for maximum compatibility
       // nnodes = std::stoull(tokens[0]);
@@ -705,10 +705,10 @@ struct Mtx2Gr : public HasNoVoidSpecialization {
 
         infile >> cur_id >> neighbor_id >> weight;
         if (cur_id == 0 || cur_id > nnodes) {
-          GALOIS_DIE("Error: node id out of range: ", cur_id);
+          GALOIS_DIE("node id out of range: ", cur_id);
         }
         if (neighbor_id == 0 || neighbor_id > nnodes) {
-          GALOIS_DIE("Error: neighbor id out of range: ", neighbor_id);
+          GALOIS_DIE("neighbor id out of range: ", neighbor_id);
         }
 
         // 1 indexed
@@ -724,7 +724,7 @@ struct Mtx2Gr : public HasNoVoidSpecialization {
 
       infile.peek();
       if (!infile.eof()) {
-        GALOIS_DIE("Error: additional lines in file");
+        GALOIS_DIE("additional lines in file");
       }
     }
     // this is for the progress print
@@ -2236,7 +2236,7 @@ struct Dimacs2Gr : public HasNoVoidSpecialization {
         }
       }
       if (tokens.size() < 3 || tokens[0].compare("p") != 0) {
-        GALOIS_DIE("Unknown problem specification line: ", line.str());
+        GALOIS_DIE("unknown problem specification line: ", line.str());
       }
       // Prefer C functions for maximum compatibility
       // nnodes = std::stoull(tokens[tokens.size() - 2]);
@@ -2270,10 +2270,10 @@ struct Dimacs2Gr : public HasNoVoidSpecialization {
 
         infile >> cur_id >> neighbor_id >> weight;
         if (cur_id == 0 || cur_id > nnodes) {
-          GALOIS_DIE("Error: node id out of range: ", cur_id);
+          GALOIS_DIE("node id out of range: ", cur_id);
         }
         if (neighbor_id == 0 || neighbor_id > nnodes) {
-          GALOIS_DIE("Error: neighbor id out of range: ", neighbor_id);
+          GALOIS_DIE("neighbor id out of range: ", neighbor_id);
         }
 
         // 1 indexed
@@ -2288,7 +2288,7 @@ struct Dimacs2Gr : public HasNoVoidSpecialization {
 
       infile.peek();
       if (!infile.eof()) {
-        GALOIS_DIE("Error: additional lines in file");
+        GALOIS_DIE("additional lines in file");
       }
     }
 
@@ -2333,7 +2333,7 @@ struct Pbbs2Gr : public HasOnlyVoidSpecialization {
 
     infile >> header >> nnodes >> nedges;
     if (header != "AdjacencyGraph") {
-      GALOIS_DIE("Error: unknown file format");
+      GALOIS_DIE("unknown file format");
     }
 
     p.setNumNodes(nnodes);


### PR DESCRIPTION
Error messages should be user actionable if possible. This means that
they should expressed in terms of user-facing abstractions (e.g., files,
command line arguments) and phrased in such a way as to indicate what
the remedy should be.

Along the way, give errors with the same causes the same message, adopt
an initial lower-case for messages, and remove excess developer-facing
context. The line number printed by GALOIS_DIE should be sufficient to
identify the particular GALOIS_DIE statement.