### PR TITLE
Graph in Pangolin -> PangolinGraph

### DIFF
--- a/libpangolin/include/pangolin/BfsMining/embedding_list.h
+++ b/libpangolin/include/pangolin/BfsMining/embedding_list.h
@@ -11,7 +11,7 @@ class EmbeddingList {
 public:
   EmbeddingList() {}
   ~EmbeddingList() {}
-  void init(Graph& graph, unsigned max_size = 2, bool is_dag = false);
+  void init(PangolinGraph& graph, unsigned max_size = 2, bool is_dag = false);
   VertexId get_vid(unsigned level, size_t id) const {
     return vid_lists[level][id];
   }

--- a/libpangolin/include/pangolin/BfsMining/vertex_miner_api.h
+++ b/libpangolin/include/pangolin/BfsMining/vertex_miner_api.h
@@ -11,22 +11,22 @@ public:
     return true;
   }
   // toAdd (only add non-automorphisms)
-  static inline bool toAdd(unsigned n, Graph& g, const EmbeddingTy& emb,
+  static inline bool toAdd(unsigned n, PangolinGraph& g, const EmbeddingTy& emb,
                            unsigned pos, VertexId dst) {
     return !is_vertex_automorphism(n, g, emb, pos, dst);
   }
-  static inline bool toAddOrdered(unsigned, Graph&, const EmbeddingTy&,
-                                  unsigned, VertexId, Graph&) {
+  static inline bool toAddOrdered(unsigned, PangolinGraph&, const EmbeddingTy&,
+                                  unsigned, VertexId, PangolinGraph&) {
     return true;
   }
   // given an embedding, return its pattern id (hash value)
-  static inline unsigned getPattern(unsigned, Graph&, unsigned, VertexId,
-                                    const EmbeddingTy&, unsigned) {
+  static inline unsigned getPattern(unsigned, PangolinGraph&, unsigned,
+                                    VertexId, const EmbeddingTy&, unsigned) {
     return 0;
   }
 
 protected:
-  static inline bool is_vertex_automorphism(unsigned n, Graph& g,
+  static inline bool is_vertex_automorphism(unsigned n, PangolinGraph& g,
                                             const EmbeddingTy& emb,
                                             unsigned idx, VertexId dst) {
     // unsigned n = emb.size();
@@ -49,7 +49,7 @@ protected:
         return true;
     return false;
   }
-  static inline bool is_all_connected_dag(Graph& g, unsigned dst,
+  static inline bool is_all_connected_dag(PangolinGraph& g, unsigned dst,
                                           const EmbeddingTy& emb, unsigned end,
                                           unsigned start = 0) {
     assert(end > 0);
@@ -63,7 +63,7 @@ protected:
     }
     return all_connected;
   }
-  static inline bool is_connected(Graph& g, unsigned a, unsigned b) {
+  static inline bool is_connected(PangolinGraph& g, unsigned a, unsigned b) {
     if (g.get_degree(a) == 0 || g.get_degree(b) == 0)
       return false;
     unsigned key    = a;
@@ -76,16 +76,17 @@ protected:
     auto end   = g.edge_end(search);
     return binary_search(g, key, begin, end);
   }
-  static inline int is_connected_dag(Graph& g, unsigned key, unsigned search) {
+  static inline int is_connected_dag(PangolinGraph& g, unsigned key,
+                                     unsigned search) {
     if (g.get_degree(search) == 0)
       return false;
     auto begin = g.edge_begin(search);
     auto end   = g.edge_end(search);
     return binary_search(g, key, begin, end);
   }
-  static inline bool binary_search(Graph& g, unsigned key,
-                                   Graph::edge_iterator begin,
-                                   Graph::edge_iterator end) {
+  static inline bool binary_search(PangolinGraph& g, unsigned key,
+                                   PangolinGraph::edge_iterator begin,
+                                   PangolinGraph::edge_iterator end) {
     auto l = begin;
     auto r = end - 1;
     while (r >= l) {
@@ -100,7 +101,7 @@ protected:
     }
     return false;
   }
-  static inline unsigned find_motif_pattern_id(unsigned n, Graph& g,
+  static inline unsigned find_motif_pattern_id(unsigned n, PangolinGraph& g,
                                                unsigned idx, VertexId dst,
                                                const EmbeddingTy& emb,
                                                BYTE* pre_pid,

--- a/libpangolin/include/pangolin/gtypes.h
+++ b/libpangolin/include/pangolin/gtypes.h
@@ -31,10 +31,10 @@ typedef galois::gstl::Vector<IntSet> IntSets;
 // typedef std::set<int> IntSet;
 // typedef std::vector<IntSet> IntSets;
 
-struct Graph
+class PangolinGraph
     : public galois::graphs::LC_CSR_Graph<uint32_t, void>::with_numa_alloc<
           true>::type ::with_no_lockable<true>::type {
-
+public:
   uint32_t* degrees;
   void degree_counting() {
     degrees = new uint32_t[numNodes];
@@ -48,4 +48,4 @@ struct Graph
   uint32_t get_degree(uint32_t n) { return degrees[n]; }
 };
 
-typedef Graph::GraphNode GNode;
+typedef PangolinGraph::GraphNode GNode;

--- a/libpangolin/include/pangolin/mgraph.h
+++ b/libpangolin/include/pangolin/mgraph.h
@@ -231,7 +231,7 @@ public:
     num_edges_    = el.size();
     MakeGraphFromEL();
   }
-  void read_gr(Graph& g) {
+  void read_gr(PangolinGraph& g) {
     num_vertices_ = g.size();
     for (auto it = g.begin(); it != g.end(); it++) {
       GNode src = *it;

--- a/libpangolin/include/pangolin/miner.h
+++ b/libpangolin/include/pangolin/miner.h
@@ -141,8 +141,8 @@ public:
   }
 
 protected:
-  Graph graph;
-  Graph pattern;
+  PangolinGraph graph;
+  PangolinGraph pattern;
   unsigned max_size;
   int num_threads;
   unsigned max_degree;
@@ -183,7 +183,7 @@ protected:
         return true;
     return false;
   }
-  unsigned get_degree(Graph* g, VertexId vid) {
+  unsigned get_degree(PangolinGraph* g, VertexId vid) {
     return std::distance(g->edge_begin(vid), g->edge_end(vid));
   }
   inline unsigned intersect_merge(unsigned src, unsigned dst) {
@@ -337,8 +337,8 @@ protected:
     // return serial_search(key, begin, end);
     return binary_search(key, begin, end);
   }
-  inline bool serial_search(unsigned key, Graph::edge_iterator begin,
-                            Graph::edge_iterator end) {
+  inline bool serial_search(unsigned key, PangolinGraph::edge_iterator begin,
+                            PangolinGraph::edge_iterator end) {
     for (auto offset = begin; offset != end; ++offset) {
       unsigned d = graph.getEdgeDst(offset);
       if (d == key)
@@ -348,8 +348,8 @@ protected:
     }
     return false;
   }
-  inline bool binary_search(unsigned key, Graph::edge_iterator begin,
-                            Graph::edge_iterator end) {
+  inline bool binary_search(unsigned key, PangolinGraph::edge_iterator begin,
+                            PangolinGraph::edge_iterator end) {
     auto l = begin;
     auto r = end - 1;
     while (r >= l) {
@@ -364,7 +364,7 @@ protected:
     }
     return false;
   }
-  inline int binary_search(unsigned key, Graph::edge_iterator begin,
+  inline int binary_search(unsigned key, PangolinGraph::edge_iterator begin,
                            int length) {
     if (length < 1)
       return -1;
@@ -461,7 +461,7 @@ protected:
     return h.get_value();
   }
 
-  // unsigned orientation(Graph &og, Graph &g);
+  // unsigned orientation(PangolinGraph &og, PangolinGraph &g);
 };
 
 #endif // MINER_HPP_

--- a/libpangolin/include/pangolin/util.h
+++ b/libpangolin/include/pangolin/util.h
@@ -7,7 +7,7 @@
 
 namespace util {
 
-void print_graph(Graph& graph) {
+void print_graph(PangolinGraph& graph) {
   for (GNode n : graph) {
     std::cout << "vertex " << n << ": label = " << graph.getData(n)
               << ": degree = " << graph.get_degree(n) << " edgelist = [ ";
@@ -17,7 +17,7 @@ void print_graph(Graph& graph) {
   }
 }
 
-void genGraph(MGraph& mg, Graph& g) {
+void genGraph(MGraph& mg, PangolinGraph& g) {
   g.allocateFrom(mg.num_vertices(), mg.num_edges());
   g.constructNodes();
   for (size_t i = 0; i < mg.num_vertices(); i++) {
@@ -31,7 +31,7 @@ void genGraph(MGraph& mg, Graph& g) {
   }
 }
 // relabel vertices by descending degree order (do not apply to weighted graphs)
-void DegreeRanking(Graph& og, Graph& g) {
+void DegreeRanking(PangolinGraph& og, PangolinGraph& g) {
   std::cout << " Relabeling vertices by descending degree order\n";
   std::vector<IndexT> old_degrees(og.size(), 0);
   galois::do_all(
@@ -76,7 +76,7 @@ void DegreeRanking(Graph& og, Graph& g) {
   g.sortAllEdgesByDst();
 }
 
-unsigned orientation(Graph& og, Graph& g) {
+unsigned orientation(PangolinGraph& og, PangolinGraph& g) {
   galois::StatTimer Tdag("DAG");
   Tdag.start();
   std::cout << "Orientation enabled, using DAG\n";
@@ -140,8 +140,8 @@ unsigned orientation(Graph& og, Graph& g) {
 
 // relabel is needed when we use DAG as input graph, and it is disabled when we
 // use symmetrized graph
-unsigned read_graph(Graph& graph, std::string filetype, std::string filename,
-                    bool need_dag = false) {
+unsigned read_graph(PangolinGraph& graph, std::string filetype,
+                    std::string filename, bool need_dag = false) {
   MGraph mgraph(need_dag);
   unsigned max_degree = 0;
   if (filetype == "txt") {
@@ -159,7 +159,7 @@ unsigned read_graph(Graph& graph, std::string filetype, std::string filename,
   } else if (filetype == "gr") {
     printf("Reading .gr file: %s\n", filename.c_str());
     if (need_dag) {
-      Graph g_temp;
+      PangolinGraph g_temp;
       galois::graphs::readGraph(g_temp, filename);
       max_degree = orientation(g_temp, graph);
     } else {

--- a/libpangolin/src/BfsMining/embedding_list.cpp
+++ b/libpangolin/src/BfsMining/embedding_list.cpp
@@ -1,7 +1,7 @@
 #include "pangolin/BfsMining/embedding_list.h"
 
 template <typename ElementType, typename EmbeddingType>
-void EmbeddingList<ElementType, EmbeddingType>::init(Graph& graph,
+void EmbeddingList<ElementType, EmbeddingType>::init(PangolinGraph& graph,
                                                      unsigned max_size,
                                                      bool is_dag) {
   last_level = 1;

--- a/lonestar/mining/cpu/kcl/kcl.cpp
+++ b/lonestar/mining/cpu/kcl/kcl.cpp
@@ -13,8 +13,8 @@ public:
     return pos == n - 1;
   }
   // toAdd (only add vertex connected to all the vertices in the embedding)
-  static bool toAdd(unsigned n, Graph& g, const BaseEmbedding& emb, unsigned,
-                    VertexId dst) {
+  static bool toAdd(unsigned n, PangolinGraph& g, const BaseEmbedding& emb,
+                    unsigned, VertexId dst) {
     return is_all_connected_dag(g, dst, emb, n - 1);
   }
 };

--- a/lonestar/mining/cpu/motif/motif.cpp
+++ b/lonestar/mining/cpu/motif/motif.cpp
@@ -11,9 +11,9 @@ int num_patterns[3] = {2, 6, 21};
 class MyAPI : public VertexMinerAPI<VertexEmbedding> {
 public:
   // customized pattern classification method
-  static unsigned getPattern(unsigned n, Graph& g, unsigned i, VertexId dst,
-                             const VertexEmbedding& emb, BYTE* pre_pid,
-                             unsigned pos) {
+  static unsigned getPattern(unsigned n, PangolinGraph& g, unsigned i,
+                             VertexId dst, const VertexEmbedding& emb,
+                             BYTE* pre_pid, unsigned pos) {
     assert(n < 4);
     return find_motif_pattern_id(n, g, i, dst, emb, pre_pid, pos);
   }

--- a/lonestar/mining/cpu/sgl/sgl.cpp
+++ b/lonestar/mining/cpu/sgl/sgl.cpp
@@ -16,9 +16,9 @@ uint32_t automorph_group_id[4] = {0, 0, 1, 1}; // diamond
 #include "pangolin/BfsMining/vertex_miner_api.h"
 class MyAPI : public VertexMinerAPI<BaseEmbedding> {
 public:
-  static inline bool toAddOrdered(unsigned n, Graph& g,
+  static inline bool toAddOrdered(unsigned n, PangolinGraph& g,
                                   const BaseEmbedding& emb, unsigned pos,
-                                  VertexId dst, Graph& pattern) {
+                                  VertexId dst, PangolinGraph& pattern) {
     // std::cout << "\t emb: " << emb << ", dst=" << dst << ", pos=" << pos <<
     // "\n";
     if (!fv && dst <= emb.get_vertex(0))

--- a/lonestar/mining/cpu/tc_mine/tc_mine.cpp
+++ b/lonestar/mining/cpu/tc_mine/tc_mine.cpp
@@ -15,7 +15,7 @@ public:
     return pos == n - 1;
   }
   // toAdd (only add vertex connected to all the vertices in the embedding)
-  static bool toAdd(unsigned, Graph&, const BaseEmbedding&, unsigned,
+  static bool toAdd(unsigned, PangolinGraph&, const BaseEmbedding&, unsigned,
                     VertexId) {
     return true;
   }


### PR DESCRIPTION
Graph is too common a keyword and doesn't tell a user where to
find the declaration. PangolinGraph makes this less of an issue.
Optimally everything in libpangolin should be in a pangolin
namespace; this can be resolved later.

This is in prep for Pangolin-Querying System integration being done elsewhere.