### PR TITLE
Fix evaluation order in BoilerPlate input option

### DIFF
--- a/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityAsync.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityAsync.cpp
@@ -405,7 +405,7 @@ static const char* desc = "Computes betwenness centrality in an unweighted "
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityLevel.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityLevel.cpp
@@ -286,7 +286,7 @@ constexpr static const char* const desc =
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityOuter.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityOuter.cpp
@@ -285,7 +285,7 @@ struct HasOut : public std::unary_function<GNode, bool> {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys Gal;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/bfs/bfs.cpp
+++ b/lonestar/analytics/cpu/bfs/bfs.cpp
@@ -317,7 +317,7 @@ void runAlgo(Graph& graph, const GNode& source) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/bfs/bfsDirectionOpt.cpp
+++ b/lonestar/analytics/cpu/bfs/bfsDirectionOpt.cpp
@@ -404,7 +404,7 @@ void runAlgo(Graph& graph, const GNode& source, const uint32_t runID) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/bipart/bipart.cpp
+++ b/lonestar/analytics/cpu/bipart/bipart.cpp
@@ -210,7 +210,7 @@ int hash(unsigned val) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/boruvka/Boruvka.cpp
+++ b/lonestar/analytics/cpu/boruvka/Boruvka.cpp
@@ -422,7 +422,7 @@ void run() {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/clustering/leidenClustering.cpp
+++ b/lonestar/analytics/cpu/clustering/leidenClustering.cpp
@@ -315,7 +315,7 @@ void runMultiPhaseLouvainAlgorithm(Graph& graph, uint64_t min_graph_size,
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/clustering/louvainClustering.cpp
+++ b/lonestar/analytics/cpu/clustering/louvainClustering.cpp
@@ -790,7 +790,7 @@ void runMultiPhaseLouvainAlgorithm(Graph& graph, uint32_t min_graph_size,
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/connectedcomponents/ConnectedComponents.cpp
+++ b/lonestar/analytics/cpu/connectedcomponents/ConnectedComponents.cpp
@@ -1210,7 +1210,7 @@ void run() {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/gmetis/GMetis.cpp
+++ b/lonestar/analytics/cpu/gmetis/GMetis.cpp
@@ -173,7 +173,7 @@ typedef galois::substrate::PerThreadStorage<std::map<GNode, uint64_t>>
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/independentset/IndependentSet.cpp
+++ b/lonestar/analytics/cpu/independentset/IndependentSet.cpp
@@ -702,7 +702,7 @@ void run() {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/kcore/kcore.cpp
+++ b/lonestar/analytics/cpu/kcore/kcore.cpp
@@ -229,7 +229,7 @@ void kCoreSanity(Graph& graph) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/ktruss/K-Truss.cpp
+++ b/lonestar/analytics/cpu/ktruss/K-Truss.cpp
@@ -656,7 +656,7 @@ void run() {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/ktruss/Verify.cpp
+++ b/lonestar/analytics/cpu/ktruss/Verify.cpp
@@ -201,7 +201,7 @@ bool isSupportNoLessThanJ(Graph& g, GNode src, GNode dst, unsigned int j) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/matching/bipartite-mcm.cpp
+++ b/lonestar/analytics/cpu/matching/bipartite-mcm.cpp
@@ -1195,8 +1195,7 @@ void start() {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url,
-                (inputFile.empty() ? nullptr : inputFile.c_str()));
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/matrixcompletion/matrixCompletion.cpp
+++ b/lonestar/analytics/cpu/matrixcompletion/matrixCompletion.cpp
@@ -1497,7 +1497,7 @@ void run() {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/pagerank/PageRank-pull.cpp
+++ b/lonestar/analytics/cpu/pagerank/PageRank-pull.cpp
@@ -268,7 +268,7 @@ void prResidual(Graph& graph) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/pagerank/PageRank-push.cpp
+++ b/lonestar/analytics/cpu/pagerank/PageRank-push.cpp
@@ -188,7 +188,7 @@ void syncPageRank(Graph& graph) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/pointstoanalysis/PointsTo.cpp
+++ b/lonestar/analytics/cpu/pointstoanalysis/PointsTo.cpp
@@ -796,7 +796,7 @@ void runPTA(PTAClass& pta, Alloc& nodeAllocator) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/preflowpush/Preflowpush.cpp
+++ b/lonestar/analytics/cpu/preflowpush/Preflowpush.cpp
@@ -836,7 +836,7 @@ struct PreflowPush {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/sssp/SSSP.cpp
+++ b/lonestar/analytics/cpu/sssp/SSSP.cpp
@@ -350,7 +350,7 @@ void topoTileAlgo(Graph& graph, const GNode& source) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/triangles/Triangles.cpp
+++ b/lonestar/analytics/cpu/triangles/Triangles.cpp
@@ -465,7 +465,7 @@ void readGraph(Graph& graph) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/analytics/cpu/triangles/Triangles_AOS.cpp
+++ b/lonestar/analytics/cpu/triangles/Triangles_AOS.cpp
@@ -298,7 +298,7 @@ void readGraph(Graph& graph) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/eda/cpu/SPRoute/BoilerPlate.h
+++ b/lonestar/eda/cpu/SPRoute/BoilerPlate.h
@@ -34,7 +34,7 @@ static void LonestarPrintVersion(llvm::raw_ostream& out) {
 
 //! initialize lonestar benchmark
 void LonestarStart(int argc, char** argv, const char* app, const char* desc,
-                   const char* url, const char* input) {
+                   const char* url, llvm::cl::opt<std::string>* input) {
   llvm::cl::SetVersionPrinter(LonestarPrintVersion);
   llvm::cl::ParseCommandLineOptions(argc, argv);
   numThreads = galois::setActiveThreads(numThreads);
@@ -63,7 +63,7 @@ void LonestarStart(int argc, char** argv, const char* app, const char* desc,
   galois::runtime::reportParam("(NULL)", "Threads", numThreads);
   galois::runtime::reportParam("(NULL)", "Hosts", 1);
   if (input) {
-    galois::runtime::reportParam("(NULL)", "Input", input);
+    galois::runtime::reportParam("(NULL)", "Input", input->getValue());
   }
 
   char name[256];

--- a/lonestar/eda/cpu/SPRoute/main.cpp
+++ b/lonestar/eda/cpu/SPRoute/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
   }*/
 
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::preAlloc(numThreads * 2);
 

--- a/lonestar/eda/cpu/aigRewriting/main.cpp
+++ b/lonestar/eda/cpu/aigRewriting/main.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[]) {
 
   // shared-memory system object initializes global variables for galois
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   int nThreads         = numThreads;
   std::string path     = inputFile;

--- a/lonestar/liblonestar/include/Lonestar/BoilerPlate.h
+++ b/lonestar/liblonestar/include/Lonestar/BoilerPlate.h
@@ -31,6 +31,6 @@ extern llvm::cl::opt<std::string> statFile;
 
 //! initialize lonestar benchmark
 void LonestarStart(int argc, char** argv, const char* app, const char* desc,
-                   const char* url, const char* input);
+                   const char* url, llvm::cl::opt<std::string>* input);
 void LonestarStart(int argc, char** argv);
 #endif

--- a/lonestar/liblonestar/src/BoilerPlate.cpp
+++ b/lonestar/liblonestar/src/BoilerPlate.cpp
@@ -47,7 +47,7 @@ void LonestarStart(int argc, char** argv) {
 
 //! initialize lonestar benchmark
 void LonestarStart(int argc, char** argv, const char* app, const char* desc,
-                   const char* url, const char* input) {
+                   const char* url, llvm::cl::opt<std::string>* input) {
   llvm::cl::SetVersionPrinter(LonestarPrintVersion);
   llvm::cl::ParseCommandLineOptions(argc, argv);
   numThreads = galois::setActiveThreads(numThreads);
@@ -81,7 +81,7 @@ void LonestarStart(int argc, char** argv, const char* app, const char* desc,
   galois::runtime::reportParam("(NULL)", "Threads", numThreads);
   galois::runtime::reportParam("(NULL)", "Hosts", 1);
   if (input) {
-    galois::runtime::reportParam("(NULL)", "Input", input);
+    galois::runtime::reportParam("(NULL)", "Input", input->getValue());
   }
 
   char name[256];

--- a/lonestar/scientific/cpu/delaunayrefinement/DelaunayRefinement.cpp
+++ b/lonestar/scientific/cpu/delaunayrefinement/DelaunayRefinement.cpp
@@ -128,7 +128,7 @@ struct DetLessThan {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulation.cpp
+++ b/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulation.cpp
@@ -513,7 +513,7 @@ static void writeMesh(const std::string& filename, Graph& graph) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulationDet.cpp
+++ b/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulationDet.cpp
@@ -714,7 +714,7 @@ void deleteRounds(Rounds& rounds) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, url, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, url, &inputFile);
 
   galois::StatTimer totalTime("TimerTotal");
   totalTime.start();

--- a/lonestar/tutorial_examples/CountLevels.cpp
+++ b/lonestar/tutorial_examples/CountLevels.cpp
@@ -120,7 +120,7 @@ void bfsSerial(Graph& graph, GNode source) {
 
 int main(int argc, char** argv) {
   galois::SharedMemSys G;
-  LonestarStart(argc, argv, name, desc, nullptr, inputFile.c_str());
+  LonestarStart(argc, argv, name, desc, nullptr, &inputFile);
 
   galois::StatTimer OT("OverheadTime");
   OT.start();


### PR DESCRIPTION
Command line option objects are populated during LonestarStart call so
we cannot pass their values to LonestarStart directly. Pass a pointer
instead.

I also considered using std::optional<> instead of a pointer here, but
std::optional for reference types is not in the C++17 standard.