### PR TITLE
Report error when k argument is invalid

### DIFF
--- a/lonestar/mining/cpu/fsm/fsm.cpp
+++ b/lonestar/mining/cpu/fsm/fsm.cpp
@@ -14,7 +14,10 @@ class AppMiner : public EdgeMiner<LabeledElement, EdgeEmbedding, MyAPI, true> {
 public:
   AppMiner(unsigned ms, int nt)
       : EdgeMiner<LabeledElement, EdgeEmbedding, MyAPI, true>(ms, nt) {
-    assert(ms > 1);
+    if (ms <= 1) {
+      printf("ERROR: command line argument k must be 2 or greater\n");
+      exit(1);
+    }
     if (filetype == "gr") {
       printf("ERROR: gr file is not acceptable for FSM. Add -ft=adj and use "
              "adj file instead.\n");

--- a/lonestar/mining/cpu/kcl/kcl.cpp
+++ b/lonestar/mining/cpu/kcl/kcl.cpp
@@ -24,7 +24,10 @@ public:
   AppMiner(unsigned ms, int nt)
       : VertexMiner<SimpleElement, BaseEmbedding, MyAPI, true>(ms, nt,
                                                                nblocks) {
-    assert(ms > 2);
+    if (ms <= 2) {
+      printf("ERROR: command line argument k must be 3 or greater\n");
+      exit(1);
+    }
     set_num_patterns(1);
   }
   ~AppMiner() {}

--- a/lonestar/mining/cpu/motif/motif.cpp
+++ b/lonestar/mining/cpu/motif/motif.cpp
@@ -25,7 +25,10 @@ public:
   AppMiner(unsigned ms, int nt)
       : VertexMiner<SimpleElement, VertexEmbedding, MyAPI, false, false, true>(
             ms, nt, nblocks) {
-    assert(ms > 2);
+    if (ms <= 2) {
+      printf("ERROR: command line argument k must be 3 or greater\n");
+      exit(1);
+    }
     set_num_patterns(num_patterns[k - 3]);
   }
   ~AppMiner() {}

--- a/lonestar/mining/cpu/sgl/sgl.cpp
+++ b/lonestar/mining/cpu/sgl/sgl.cpp
@@ -55,7 +55,10 @@ public:
   AppMiner(unsigned ms, int nt)
       : VertexMiner<SimpleElement, BaseEmbedding, MyAPI, false, true, false,
                     true>(ms, nt, nblocks) {
-    assert(ms > 2);
+    if (ms <= 2) {
+      printf("ERROR: command line argument k must be 3 or greater\n");
+      exit(1);
+    }
   }
   ~AppMiner() {}
   void print_output() {

--- a/lonestar/mining/cpu/tc_mine/tc_mine.cpp
+++ b/lonestar/mining/cpu/tc_mine/tc_mine.cpp
@@ -26,7 +26,10 @@ public:
   AppMiner(unsigned ms, int nt)
       : VertexMiner<SimpleElement, BaseEmbedding, MyAPI, true>(ms, nt,
                                                                nblocks) {
-    assert(ms == 3);
+    if (ms != 3) {
+      printf("ERROR: command line argument k must be 3\n");
+      exit(1);
+    }
     set_num_patterns(1);
   }
   ~AppMiner() {}


### PR DESCRIPTION
For user-controllable parameters, it makes more sense to fail more
visibly when values are invalid rather than using an assertion. The
latter will only report an issue in a debug build.

There seems to be some requirement to not depend on libgalois in the mining code; otherwise, I might have used `GALOIS_ASSERT` and `gError` rather than `printf`. Also there seems to be some confusing naming where the AppMiner parameter is called `ms` (and there is a command line parameter `ms`) while the command line option is `k`. I'm not too familiar with this part of the codebase, so I left things as is.