### PR TITLE
Remove uses of unary_function and binary_function.

### DIFF
--- a/libgalois/include/galois/FlatMap.h
+++ b/libgalois/include/galois/FlatMap.h
@@ -41,8 +41,7 @@ public:
   typedef _Compare key_compare;
   typedef _Alloc allocator_type;
 
-  class value_compare
-      : public std::binary_function<value_type, value_type, bool> {
+  class value_compare {
     friend class flat_map<_Key, _Tp, _Compare, _Alloc, _Store>;
 
   protected:
@@ -64,8 +63,7 @@ private:
   _VectTy _data;
   _Compare _comp;
 
-  class value_key_compare
-      : public std::binary_function<value_type, key_type, bool> {
+  class value_key_compare {
     friend class flat_map<_Key, _Tp, _Compare, _Alloc, _Store>;
 
   protected:

--- a/libgalois/include/galois/ParallelSTL.h
+++ b/libgalois/include/galois/ParallelSTL.h
@@ -98,7 +98,7 @@ struct sort_helper {
 
   //! Not equal in terms of less-than
   template <class value_type>
-  struct neq_to : public std::binary_function<value_type, value_type, bool> {
+  struct neq_to {
     Compare comp;
     neq_to(Compare c) : comp(c) {}
     bool operator()(const value_type& a, const value_type& b) const {

--- a/libgalois/include/galois/PerThreadContainer.h
+++ b/libgalois/include/galois/PerThreadContainer.h
@@ -59,9 +59,7 @@ enum GlobalPos { GLOBAL_BEGIN, GLOBAL_END };
 #ifdef ADAPTOR_BASED_OUTER_ITER
 
 template <typename PerThrdCont>
-struct WLindexer
-    : public std::unary_function<unsigned,
-                                 typename PerThrdCont::container_type&> {
+struct WLindexer {
   typedef typename PerThrdCont::container_type Ret_ty;
 
   PerThrdCont* wl;

--- a/libgalois/include/galois/TwoLevelIterator.h
+++ b/libgalois/include/galois/TwoLevelIterator.h
@@ -570,42 +570,39 @@ make_two_level_end(Outer beg, Outer end, InnerBegFn innerBegFn,
 
 namespace internal {
 template <typename C>
-struct GetBegin : public std::unary_function<C&, typename C::iterator> {
+struct GetBegin {
   inline typename C::iterator operator()(C& c) const { return c.begin(); }
 };
 
 template <typename C>
-struct GetEnd : public std::unary_function<C&, typename C::iterator> {
+struct GetEnd {
   inline typename C::iterator operator()(C& c) const { return c.end(); }
 };
 
 // TODO: update to c++11 names
 template <typename C>
-struct GetCbegin
-    : public std::unary_function<const C&, typename C::const_iterator> {
+struct GetCbegin {
   inline typename C::const_iterator operator()(const C& c) const {
     return c.begin();
   }
 };
 
 template <typename C>
-struct GetCend
-    : public std::unary_function<const C&, typename C::const_iterator> {
+struct GetCend {
   inline typename C::const_iterator operator()(const C& c) const {
     return c.end();
   }
 };
 
 template <typename C>
-struct GetRbegin
-    : public std::unary_function<C&, typename C::reverse_iterator> {
+struct GetRbegin {
   inline typename C::reverse_iterator operator()(C& c) const {
     return c.rbegin();
   }
 };
 
 template <typename C>
-struct GetRend : public std::unary_function<C&, typename C::reverse_iterator> {
+struct GetRend {
   inline typename C::reverse_iterator operator()(C& c) const {
     return c.rend();
   }
@@ -613,16 +610,14 @@ struct GetRend : public std::unary_function<C&, typename C::reverse_iterator> {
 
 // TODO: update to c++11 names
 template <typename C>
-struct GetCRbegin
-    : public std::unary_function<const C&, typename C::const_reverse_iterator> {
+struct GetCRbegin {
   inline typename C::const_reverse_iterator operator()(const C& c) const {
     return c.rbegin();
   }
 };
 
 template <typename C>
-struct GetCRend
-    : public std::unary_function<const C&, typename C::const_reverse_iterator> {
+struct GetCRend {
   inline typename C::const_reverse_iterator operator()(const C& c) const {
     return c.rend();
   }

--- a/libgalois/include/galois/graphs/FileGraph.h
+++ b/libgalois/include/galois/graphs/FileGraph.h
@@ -60,11 +60,11 @@ public:
   using GraphNode = uint64_t;
 
 private:
-  struct Convert32 : public std::unary_function<uint32_t, uint32_t> {
+  struct Convert32 {
     uint32_t operator()(uint32_t x) const { return convert_le32toh(x); }
   };
 
-  struct Convert64 : public std::unary_function<uint64_t, uint64_t> {
+  struct Convert64 {
     uint64_t operator()(uint64_t x) const { return convert_le64toh(x); }
   };
 

--- a/libgalois/include/galois/graphs/LC_Morph_Graph.h
+++ b/libgalois/include/galois/graphs/LC_Morph_Graph.h
@@ -178,7 +178,7 @@ protected:
   }; // end NodeInfo
 
   //! Functor that returns pointers to NodeInfo objects given references
-  struct makeGraphNode : public std::unary_function<NodeInfo&, NodeInfo*> {
+  struct makeGraphNode {
     //! Returns a pointer to the NodeInfo reference passed into this functor
     NodeInfo* operator()(NodeInfo& data) const { return &data; }
   };

--- a/libgalois/include/galois/graphs/MorphGraph.h
+++ b/libgalois/include/galois/graphs/MorphGraph.h
@@ -509,28 +509,25 @@ private: ///////////////////////////////////////////////////////////////////////
   internal::EdgeFactory<EdgeTy, Directional && !InOut> edgesF;
 
   // Helpers for iterator classes
-  struct is_node : public std::unary_function<gNode&, bool> {
+  struct is_node {
     bool operator()(const gNode& g) const { return g.active; }
   };
-  struct is_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active;
     }
   };
-  struct is_in_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_in_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active && e.isInEdge();
     }
   };
-  struct is_out_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_out_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active && !e.isInEdge();
     }
   };
-  struct makeGraphNode : public std::unary_function<gNode&, gNode*> {
+  struct makeGraphNode {
     gNode* operator()(gNode& data) const { return &data; }
   };
 

--- a/libgalois/include/galois/graphs/MorphHyperGraph.h
+++ b/libgalois/include/galois/graphs/MorphHyperGraph.h
@@ -513,28 +513,25 @@ private: ///////////////////////////////////////////////////////////////////////
   internal::EdgeFactory<EdgeTy, Directional && !InOut> edgesF;
 
   // Helpers for iterator classes
-  struct is_node : public std::unary_function<gNode&, bool> {
+  struct is_node {
     bool operator()(const gNode& g) const { return g.active; }
   };
-  struct is_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active;
     }
   };
-  struct is_in_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_in_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active && e.isInEdge();
     }
   };
-  struct is_out_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_out_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active && !e.isInEdge();
     }
   };
-  struct makeGraphNode : public std::unary_function<gNode&, gNode*> {
+  struct makeGraphNode {
     gNode* operator()(gNode& data) const { return &data; }
   };
 

--- a/libgalois/include/galois/graphs/Morph_SepInOut_Graph.h
+++ b/libgalois/include/galois/graphs/Morph_SepInOut_Graph.h
@@ -456,28 +456,25 @@ private:
   internal::EdgeFactory<EdgeTy, Directional && !InOut> edgesF;
 
   // Helpers for iterator classes
-  struct is_node : public std::unary_function<gNode&, bool> {
+  struct is_node {
     bool operator()(const gNode& g) const { return g.active; }
   };
-  struct is_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active;
     }
   };
-  struct is_in_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_in_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active && e.isInEdge();
     }
   };
-  struct is_out_edge
-      : public std::unary_function<typename gNodeTypes::EdgeInfo&, bool> {
+  struct is_out_edge {
     bool operator()(typename gNodeTypes::EdgeInfo& e) const {
       return e.first()->active && !e.isInEdge();
     }
   };
-  struct makeGraphNode : public std::unary_function<gNode&, gNode*> {
+  struct makeGraphNode {
     gNode* operator()(gNode& data) const { return &data; }
   };
 

--- a/libgalois/include/galois/runtime/Executor_Deterministic.h
+++ b/libgalois/include/galois/runtime/Executor_Deterministic.h
@@ -392,7 +392,7 @@ struct DNewItem {
 
   bool operator!=(const DNewItem<T>& o) const { return !(*this == o); }
 
-  struct GetValue : public std::unary_function<DNewItem<T>, const T&> {
+  struct GetValue {
     const T& operator()(const DNewItem<T>& x) const { return x.val; }
   };
 };
@@ -965,7 +965,7 @@ class NewWorkManager : public IdManager<OptionsTy> {
   typedef FIFO<1024, Item> ReserveTy;
   typedef worklists::PerSocketChunkFIFO<OptionsTy::ChunkSize, NewItem> NewWork;
 
-  struct GetNewItem : public std::unary_function<int, NewItemsTy&> {
+  struct GetNewItem {
     NewWorkManager* self;
     GetNewItem(NewWorkManager* s = 0) : self(s) {}
     NewItemsTy& operator()(int i) const {

--- a/libgalois/include/galois/runtime/TiledExecutor.h
+++ b/libgalois/include/galois/runtime/TiledExecutor.h
@@ -65,7 +65,7 @@ class Fixed2DGraphTiledExecutor {
    * Functor: given a graph on initialization, passing it an edge iterator
    * will return the destination of that edge in the graph.
    */
-  struct GetDst : public std::unary_function<edge_iterator, GNode> {
+  struct GetDst {
     Graph* g;
     GetDst() {}
     GetDst(Graph* _g) : g(_g) {}

--- a/libgalois/include/galois/worklists/WorkListHelpers.h
+++ b/libgalois/include/galois/worklists/WorkListHelpers.h
@@ -175,7 +175,7 @@ public:
 };
 
 template <typename T>
-struct DummyIndexer : public std::unary_function<const T&, unsigned> {
+struct DummyIndexer {
   unsigned operator()(const T&) { return 0; }
 };
 

--- a/libgalois/test/sort.cpp
+++ b/libgalois/test/sort.cpp
@@ -121,7 +121,7 @@ int do_count_if() {
 }
 
 template <typename T>
-struct mymax : std::binary_function<T, T, T> {
+struct mymax {
   T operator()(const T& x, const T& y) const { return std::max(x, y); }
 };
 

--- a/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityOuter.cpp
+++ b/lonestar/analytics/cpu/betweennesscentrality/BetweennessCentralityOuter.cpp
@@ -296,7 +296,7 @@ private:
 /**
  * Functor that indicates if a node contains outgoing edges
  */
-struct HasOut : public std::unary_function<GNode, bool> {
+struct HasOut {
   Graph* graph;
   HasOut(Graph* g) : graph(g) {}
 

--- a/lonestar/analytics/cpu/gmetis/Coarsening.cpp
+++ b/lonestar/analytics/cpu/gmetis/Coarsening.cpp
@@ -221,7 +221,7 @@ void createCoarseEdges(MetisGraph* graph) {
       galois::steal(), galois::loopname("popedge"));
 }
 
-struct HighDegreeIndexer : public std::unary_function<GNode, unsigned int> {
+struct HighDegreeIndexer {
   static GGraph* indexgraph;
   unsigned int operator()(const GNode& val) const {
     return indexgraph->getData(val, galois::MethodFlag::UNPROTECTED)
@@ -237,7 +237,7 @@ struct HighDegreeIndexer : public std::unary_function<GNode, unsigned int> {
 };
 GGraph* HighDegreeIndexer::indexgraph = 0;
 
-struct LowDegreeIndexer : public std::unary_function<GNode, unsigned int> {
+struct LowDegreeIndexer {
   unsigned int operator()(const GNode& val) const {
     unsigned x = std::distance(HighDegreeIndexer::indexgraph->edge_begin(
                                    val, galois::MethodFlag::UNPROTECTED),
@@ -250,7 +250,7 @@ struct LowDegreeIndexer : public std::unary_function<GNode, unsigned int> {
   }
 };
 
-struct WeightIndexer : public std::unary_function<GNode, int> {
+struct WeightIndexer {
   int operator()(const GNode& val) const {
     return HighDegreeIndexer::indexgraph
         ->getData(val, galois::MethodFlag::UNPROTECTED)

--- a/lonestar/analytics/cpu/matrixcompletion/matrixCompletion.cpp
+++ b/lonestar/analytics/cpu/matrixcompletion/matrixCompletion.cpp
@@ -384,7 +384,7 @@ struct SGDBlockJumpAlgo {
     size_t maxUpdates;
     galois::GAccumulator<double>* errorAccum;
 
-    struct GetDst : public std::unary_function<Graph::edge_iterator, GNode> {
+    struct GetDst {
       Graph* g;
       GetDst() {}
       GetDst(Graph* _g) : g(_g) {}

--- a/lonestar/analytics/cpu/triangle-counting/Triangles.cpp
+++ b/lonestar/analytics/cpu/triangle-counting/Triangles.cpp
@@ -140,8 +140,7 @@ struct GreaterThanOrEqual {
 };
 
 template <typename G>
-struct DegreeLess : public std::binary_function<typename G::GraphNode,
-                                                typename G::GraphNode, bool> {
+struct DegreeLess {
   typedef typename G::GraphNode N;
   G* g;
   DegreeLess(G& g) : g(&g) {}
@@ -152,9 +151,7 @@ struct DegreeLess : public std::binary_function<typename G::GraphNode,
   }
 };
 template <typename G>
-struct DegreeGreater
-    : public std::binary_function<typename G::GraphNode, typename G::GraphNode,
-                                  bool> {
+struct DegreeGreater {
   typedef typename G::GraphNode N;
   G* g;
   DegreeGreater(G& g) : g(&g) {}
@@ -165,8 +162,7 @@ struct DegreeGreater
   }
 };
 template <typename G>
-struct GetDegree
-    : public std::unary_function<typename G::GraphNode, ptrdiff_t> {
+struct GetDegree {
   typedef typename G::GraphNode N;
   G* g;
   GetDegree(G& g) : g(&g) {}

--- a/lonestar/scientific/cpu/delaunayrefinement/Verifier.h
+++ b/lonestar/scientific/cpu/delaunayrefinement/Verifier.h
@@ -28,7 +28,7 @@
 #include <iostream>
 
 class Verifier {
-  struct inconsistent : public std::unary_function<GNode, bool> {
+  struct inconsistent {
     Graph& graph;
     inconsistent(Graph& g) : graph(g) {}
 
@@ -56,7 +56,7 @@ class Verifier {
     }
   };
 
-  struct not_delaunay : public std::unary_function<GNode, bool> {
+  struct not_delaunay {
     Graph& graph;
     not_delaunay(Graph& g) : graph(g) {}
 

--- a/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulationDet.cpp
+++ b/lonestar/scientific/cpu/delaunaytriangulation/DelaunayTriangulationDet.cpp
@@ -80,7 +80,7 @@ static cll::opt<bool>
     meshGraph("meshGraph", cll::desc("Specify that the input graph is a mesh"),
               cll::init(false));
 
-struct GetPointer : public std::unary_function<Point&, Point*> {
+struct GetPointer {
   Point* operator()(Point& p) const { return &p; }
 };
 

--- a/lonestar/scientific/cpu/delaunaytriangulation/Graph.h
+++ b/lonestar/scientific/cpu/delaunaytriangulation/Graph.h
@@ -54,7 +54,7 @@ struct Searcher : private boost::noncopyable {
   Searcher(Graph& g, const Alloc& a = allocator_type())
       : graph(g), matches(a), inside(a), alloc(a) {}
 
-  struct DetLess : public std::binary_function<GNode, GNode, bool> {
+  struct DetLess {
     Graph& g;
     DetLess(Graph& x) : g(x) {}
     bool operator()(GNode a, GNode b) const {

--- a/lonestar/scientific/cpu/delaunaytriangulation/QuadTree.h
+++ b/lonestar/scientific/cpu/delaunaytriangulation/QuadTree.h
@@ -57,7 +57,7 @@ class PQuadTree {
     double best;
   };
 
-  struct DerefPointer : public std::unary_function<Point*, Point> {
+  struct DerefPointer {
     Point operator()(Point* p) const { return *p; }
   };
 
@@ -140,7 +140,7 @@ class PQuadTree {
     }
   };
 
-  struct Split : public std::unary_function<Point*, bool> {
+  struct Split {
     int index;
     TupleDataTy pivot;
     Split(int i, TupleDataTy p) : index(i), pivot(p) {}
@@ -382,7 +382,7 @@ class SQuadTree {
     double best;
   };
 
-  struct DerefPointer : public std::unary_function<Point*, Point> {
+  struct DerefPointer {
     Point operator()(Point* p) const { return *p; }
   };
 

--- a/lonestar/scientific/cpu/delaunaytriangulation/Verifier.h
+++ b/lonestar/scientific/cpu/delaunaytriangulation/Verifier.h
@@ -31,7 +31,7 @@
 #include <iostream>
 
 class Verifier {
-  struct inconsistent : public std::unary_function<GNode, bool> {
+  struct inconsistent {
     Graph* graph;
     inconsistent(Graph* g) : graph(g) {}
 
@@ -60,7 +60,7 @@ class Verifier {
     }
   };
 
-  struct not_delaunay : public std::unary_function<GNode, bool> {
+  struct not_delaunay {
     Graph* graph;
     not_delaunay(Graph* g) : graph(g) {}
 


### PR DESCRIPTION
They have been removed from the C++17 standard, but as of this commit
libc++ and libstdc++ still provide them, so this is just a
future-proofing measure. It appears that no current functionality relies
on them anyway so they can be removed without any additional
ramifications.

Fixes https://github.com/IntelligentSoftwareSystems/Galois/issues/322.