### PR TITLE
Add support library

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,8 @@ jobs:
             openmpi-bin \
             libopenmpi-dev \
             llvm-7-dev \
-            libz-dev
+            libz-dev \
+            libfmt-dev
 
           update-alternatives --install /usr/bin/clang clang /usr/bin/clang-10 50
           update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-10 50
@@ -98,7 +99,8 @@ jobs:
             libmpich-dev \
             llvm-7-dev \
             mpich \
-            zlib1g-dev
+            zlib1g-dev \
+            libfmt-dev
 
           chmod 755 /root
           useradd runner
@@ -134,7 +136,8 @@ jobs:
             libopenmpi-dev \
             llvm-7-dev \
             openmpi-bin \
-            ssh
+            ssh \
+            libfmt-dev
 
           chmod 755 /root
           useradd runner
@@ -169,7 +172,8 @@ jobs:
             libopenmpi-dev \
             llvm-7-dev \
             openmpi-bin \
-            ssh
+            ssh \
+            libfmt-dev
 
           cmake -S . -B /tmp/build -DGALOIS_ENABLE_DIST=ON -DGALOIS_ENABLE_GPU=ON
           cmake --build /tmp/build --target input
@@ -197,7 +201,8 @@ jobs:
             libopenmpi-dev \
             llvm-7-dev \
             openmpi-bin \
-            ssh
+            ssh \
+            libfmt-dev
 
           cmake -S . -B /tmp/build -DGALOIS_ENABLE_DIST=ON -DGALOIS_ENABLE_GPU=ON
           cmake --build /tmp/build --target input
@@ -208,9 +213,13 @@ jobs:
     steps:
       - checkout
       - run: |
-          # Needs to access PowerTools packages for eigen, so get access to those
+          # fmt-devel is in EPEL
+          yum -y -q install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+          # eigen3-devel needs PowerTools packages
           yum -y -q install dnf-plugins-core
           yum -y -q config-manager --set-enabled PowerTools
+
           yum -y -q install git
       - run: git submodule sync
       - run: git submodule update --init
@@ -227,7 +236,8 @@ jobs:
             mpich-devel \
             ncurses-devel \
             wget \
-            zlib-devel
+            zlib-devel \
+            fmt-devel
 
           wget -O - https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz | tar -xz -f - -C /usr/local
           ln -s /usr/local/cmake-3.17.0-Linux-x86_64/bin/cmake /usr/local/bin/cmake
@@ -253,9 +263,13 @@ jobs:
     steps:
       - checkout
       - run: |
-          # Needs to access PowerTools packages for eigen, so get access to those
+          # fmt-devel is in EPEL
+          yum -y -q install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+          # eigen3-devel needs PowerTools packages
           yum -y -q install dnf-plugins-core
           yum -y -q config-manager --set-enabled PowerTools
+
           yum -y -q install git
       - run: git submodule sync
       - run: git submodule update --init
@@ -269,7 +283,8 @@ jobs:
             make \
             ncurses-devel \
             wget \
-            zlib-devel
+            zlib-devel \
+            fmt-devel
 
           wget -O - https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.tar.gz | tar -xz -f - -C /usr/local
           ln -s /usr/local/cmake-3.17.0-Linux-x86_64/bin/cmake /usr/local/bin/cmake
@@ -309,7 +324,8 @@ jobs:
             libffi \
             llvm \
             make \
-            openmpi
+            openmpi \
+            fmt
 
           chmod 755 /root
           useradd runner
@@ -342,7 +358,8 @@ jobs:
             make \
             musl-dev \
             openssh-client \
-            zlib-dev
+            zlib-dev \
+            fmt-dev
 
           chmod 755 /root
           adduser -D runner
@@ -373,7 +390,8 @@ jobs:
             llvm-static \
             make \
             mpich-devel \
-            zlib-devel
+            zlib-devel \
+            fmt-devel
 
           chmod 755 /root
           useradd runner
@@ -407,7 +425,8 @@ jobs:
             llvm-static \
             make \
             openmpi-devel \
-            zlib-devel
+            zlib-devel \
+            fmt-devel
 
           chmod 755 /root
           useradd runner

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       before_script:
         - export CC=clang
         - export CXX=clang++
-        - brew install openmpi llvm
+        - brew install openmpi llvm fmt
         - mkdir build
         - export PATH=$PATH:/usr/local/opt/llvm/bin
         - cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DGALOIS_ENABLE_DIST=ON || exit 1
@@ -35,6 +35,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - GCC_VER=8
       addons:
@@ -54,6 +55,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - GCC_VER=9
       addons:
@@ -73,6 +75,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - GCC_VER=10
       addons:
@@ -92,6 +95,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - GCC_VER=10
         - BUILD_TYPE=Debug
@@ -112,6 +116,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - CLANG_VER=7
       addons:
@@ -132,6 +137,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - CLANG_VER=8
       addons:
@@ -152,6 +158,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - CLANG_VER=9
       addons:
@@ -172,6 +179,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - CLANG_VER=10
       addons:
@@ -192,6 +200,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
     - env:
         - CLANG_VER=10
         - BUILD_TYPE=Debug
@@ -213,6 +222,7 @@ matrix:
             - libopenmpi-dev
             - llvm-7-dev
             - libz-dev
+            - libfmt-dev
 
 before_script:
   # Depending on whether GCC_VER or CLANG_VER is set and nonempty,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,7 @@ add_custom_target(lib)
 add_custom_target(apps)
 
 # Core libraries (lib)
+add_subdirectory(libsupport)
 add_subdirectory(libgalois)
 if (GALOIS_ENABLE_DIST)
   find_package(MPI REQUIRED)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ At the minimum, Galois depends on the following software:
 - A modern C++ compiler compliant with the C++-17 standard (gcc >= 7, Intel >= 19.0.1, clang >= 7.0)
 - CMake (>= 3.13)
 - Boost library (>= 1.58.0, we recommend building/installing the full library)
-- LLVM (>= 7.0 with RTTI support)
+- libllvm (>= 7.0 with RTTI support)
+- libfmt (>= 4.0)
 
 Here are the dependencies for the optional features: 
 

--- a/libsupport/CMakeLists.txt
+++ b/libsupport/CMakeLists.txt
@@ -1,0 +1,43 @@
+add_library(galois_support STATIC)
+add_library(Galois::support ALIAS galois_support)
+set_target_properties(galois_support PROPERTIES EXPORT_NAME support)
+add_dependencies(lib galois_support)
+
+set(sources
+        src/GetEnv.cpp
+        src/Logging.cpp
+)
+
+target_sources(galois_support PRIVATE ${sources})
+
+target_include_directories(galois_support PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+find_package(fmt REQUIRED)
+if (fmt_VERSION VERSION_LESS 4)
+  message(FATAL_ERROR "fmt must be version 4 or higher. Found ${fmt_VERSION}.")
+endif()
+target_link_libraries(galois_support fmt::fmt)
+
+add_subdirectory(test)
+
+install(
+  DIRECTORY include/
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  COMPONENT dev
+  FILES_MATCHING PATTERN "*.h"
+)
+
+install(
+  TARGETS galois_support
+  EXPORT GaloisTargets
+  LIBRARY
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    COMPONENT shlib
+  ARCHIVE
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    COMPONENT lib
+  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)

--- a/libsupport/include/galois/GetEnv.h
+++ b/libsupport/include/galois/GetEnv.h
@@ -1,0 +1,29 @@
+#ifndef GALOIS_LIBSUPPORT_GALOIS_GET_ENV_H_
+#define GALOIS_LIBSUPPORT_GALOIS_GET_ENV_H_
+
+#include <string>
+
+namespace galois {
+
+/// Return true if the environment variable is set.
+///
+/// This function simply tests for the presence of an environment variable; in
+/// contrast, bool GetEnv(std::string, bool&) checks if the value of the
+/// environment variable matches common truthy and falsey values.
+bool GetEnv(const std::string& var_name);
+
+/// Return true if environment variable is set, and extract its value into
+/// ret_val parameter.
+///
+/// \param var_name name of the variable
+/// \param[out] ret_val where to store the value of environment variable
+/// \return true if environment variable set and value was successfully parsed;
+///   false otherwise
+bool GetEnv(const std::string& var_name, bool* ret);
+bool GetEnv(const std::string& var_name, int* ret);
+bool GetEnv(const std::string& var_name, double* ret);
+bool GetEnv(const std::string& var_name, std::string* ret);
+
+} // end namespace galois
+
+#endif

--- a/libsupport/include/galois/Logging.h
+++ b/libsupport/include/galois/Logging.h
@@ -1,0 +1,114 @@
+#ifndef GALOIS_LIBSUPPORT_GALOIS_LOGGING_H_
+#define GALOIS_LIBSUPPORT_GALOIS_LOGGING_H_
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <sstream>
+#include <string>
+#include <system_error>
+
+// Small patch to work with libfmt 4.0, which is the version in Ubuntu 18.04.
+#ifndef FMT_STRING
+#define FMT_STRING(...) __VA_ARGS__
+#endif
+
+#if FMT_VERSION >= 60000
+/// Introduce std::error_code to the fmt library. Otherwise, they will be
+/// printed using ostream<< formatting (i.e., as an int).
+template <>
+struct fmt::formatter<std::error_code> : formatter<string_view> {
+
+  template <typename FormatterContext>
+  auto format(std::error_code c, FormatterContext& ctx) {
+    return formatter<string_view>::format(c.message(), ctx);
+  }
+};
+#endif
+
+namespace galois {
+
+enum class LogLevel {
+  Debug   = 0,
+  Verbose = 1,
+  // Info = 2,  currently unused
+  Warning = 3,
+  Error   = 4,
+};
+
+namespace internal {
+
+void LogString(LogLevel level, const std::string& s);
+
+}
+
+/// Log at a specific LogLevel.
+///
+/// \tparam F         string-like type
+/// \param fmt_string a C++20-style fmt string (e.g., "hello {}")
+/// \param args       arguments to fmt interpolation
+template <typename F, typename... Args>
+void Log(LogLevel level, F fmt_string, Args&&... args) {
+  std::string s = fmt::format(fmt_string, std::forward<Args>(args)...);
+  internal::LogString(level, s);
+}
+
+/// Log at a specific LogLevel with source code information.
+///
+/// \tparam F         string-like type
+/// \param file_name  file name
+/// \param line_no    line number
+/// \param fmt_string a C++20-style fmt string (e.g., "hello {}")
+/// \param args       arguments to fmt interpolation
+template <typename F, typename... Args>
+void LogLine(LogLevel level, const char* file_name, int line_no, F fmt_string,
+             Args&&... args) {
+  std::string s         = fmt::format(fmt_string, std::forward<Args>(args)...);
+  std::string with_line = fmt::format("{}:{}: {}", file_name, line_no, s);
+  internal::LogString(level, with_line);
+}
+
+} // end namespace galois
+
+#define GALOIS_LOG_FATAL(fmt_string, ...)                                      \
+  do {                                                                         \
+    ::galois::LogLine(::galois::LogLevel::Error, __FILE__, __LINE__,           \
+                      FMT_STRING(fmt_string), ##__VA_ARGS__);                  \
+    ::std::abort();                                                            \
+  } while (0)
+#define GALOIS_LOG_ERROR(fmt_string, ...)                                      \
+  do {                                                                         \
+    ::galois::LogLine(::galois::LogLevel::Error, __FILE__, __LINE__,           \
+                      FMT_STRING(fmt_string), ##__VA_ARGS__);                  \
+  } while (0)
+#define GALOIS_LOG_WARN(fmt_string, ...)                                       \
+  do {                                                                         \
+    ::galois::LogLine(::galois::LogLevel::Warning, __FILE__, __LINE__,         \
+                      FMT_STRING(fmt_string), ##__VA_ARGS__);                  \
+  } while (0)
+#define GALOIS_LOG_VERBOSE(fmt_string, ...)                                    \
+  do {                                                                         \
+    ::galois::LogLine(::galois::LogLevel::Verbose, __FILE__, __LINE__,         \
+                      FMT_STRING(fmt_string), ##__VA_ARGS__);                  \
+  } while (0)
+
+#ifndef NDEBUG
+#define GALOIS_LOG_DEBUG(fmt_string, ...)                                      \
+  do {                                                                         \
+    ::galois::LogLine(::galois::LogLevel::Debug, __FILE__, __LINE__,           \
+                      FMT_STRING(fmt_string), ##__VA_ARGS__);                  \
+  } while (0)
+#else
+#define GALOIS_LOG_DEBUG(...)
+#endif
+
+#define GALOIS_LOG_ASSERT(cond)                                                \
+  do {                                                                         \
+    if (!(cond)) {                                                             \
+      ::galois::LogLine(::galois::LogLevel::Error, __FILE__, __LINE__,         \
+                        "assertion not true: {}", #cond);                      \
+      ::std::abort();                                                          \
+    }                                                                          \
+  } while (0)
+
+#endif

--- a/libsupport/src/GetEnv.cpp
+++ b/libsupport/src/GetEnv.cpp
@@ -1,0 +1,79 @@
+#include "galois/GetEnv.h"
+
+#include <cstdlib>
+#include <stdexcept>
+
+namespace {
+
+bool Convert(const std::string& var_val, bool* ret) {
+  // TODO(ddn): strip whitespace, case-insensitive?
+  if (var_val == "True" || var_val == "1" || var_val == "true") {
+    *ret = true;
+    return true;
+  }
+
+  if (var_val == "False" || var_val == "0" || var_val == "false") {
+    *ret = false;
+    return true;
+  }
+
+  return false;
+}
+
+bool Convert(const std::string& var_val, int* ret) {
+  try {
+    *ret = std::stoi(var_val);
+  } catch (std::invalid_argument&) {
+    return false;
+  } catch (std::out_of_range&) {
+    return false;
+  }
+  return true;
+}
+
+bool Convert(const std::string& var_val, double* ret) {
+  try {
+    *ret = std::stod(var_val);
+  } catch (std::invalid_argument&) {
+    return false;
+  } catch (std::out_of_range&) {
+    return false;
+  }
+  return true;
+}
+
+bool Convert(const std::string& var_val, std::string* ret) {
+  *ret = var_val;
+  return true;
+}
+
+template <typename T>
+bool GenericGetEnv(const std::string& var_name, T* ret) {
+  char* var_val = std::getenv(var_name.c_str());
+  if (!var_val) {
+    return false;
+  }
+  return Convert(var_val, ret);
+}
+
+} // namespace
+
+bool galois::GetEnv(const std::string& var_name, bool* ret) {
+  return GenericGetEnv(var_name, ret);
+}
+
+bool galois::GetEnv(const std::string& var_name, int* ret) {
+  return GenericGetEnv(var_name, ret);
+}
+
+bool galois::GetEnv(const std::string& var_name, std::string* ret) {
+  return GenericGetEnv(var_name, ret);
+}
+
+bool galois::GetEnv(const std::string& var_name, double* ret) {
+  return GenericGetEnv(var_name, ret);
+}
+
+bool galois::GetEnv(const std::string& var_name) {
+  return std::getenv(var_name.c_str()) != nullptr;
+}

--- a/libsupport/src/Logging.cpp
+++ b/libsupport/src/Logging.cpp
@@ -1,0 +1,43 @@
+#include "galois/Logging.h"
+
+#include <iostream>
+#include <mutex>
+
+#include "galois/GetEnv.h"
+
+namespace {
+
+void PrintString(bool error, bool flush, const std::string& prefix,
+                 const std::string& s) {
+  static std::mutex lock;
+  std::lock_guard<std::mutex> lg(lock);
+
+  std::ostream& o = error ? std::cerr : std::cout;
+  if (!prefix.empty()) {
+    o << prefix << ": ";
+  }
+  o << s << "\n";
+  if (flush) {
+    o.flush();
+  }
+}
+
+} // end unnamed namespace
+
+void galois::internal::LogString(galois::LogLevel level, const std::string& s) {
+  switch (level) {
+  case LogLevel::Debug:
+    return PrintString(true, false, "DEBUG", s);
+  case LogLevel::Verbose:
+    if (galois::GetEnv("GALOIS_LOG_VERBOSE")) {
+      return PrintString(true, false, "VERBOSE", s);
+    }
+    return;
+  case LogLevel::Warning:
+    return PrintString(true, false, "WARNING", s);
+  case LogLevel::Error:
+    return PrintString(true, false, "ERROR", s);
+  default:
+    std::abort();
+  }
+}

--- a/libsupport/test/CMakeLists.txt
+++ b/libsupport/test/CMakeLists.txt
@@ -1,0 +1,20 @@
+function(add_test_unit name)
+  set(test_name unit-${name})
+
+  add_executable(${test_name} ${name}.cpp)
+  target_link_libraries(${test_name} galois_support)
+
+  set(command_line "$<TARGET_FILE:${test_name}>")
+
+  add_test(NAME ${test_name} COMMAND ${command_line})
+
+  # Allow parallel tests
+  set_tests_properties(${test_name}
+    PROPERTIES
+      ENVIRONMENT GALOIS_DO_NOT_BIND_THREADS=1
+      LABELS quick
+    )
+endfunction()
+
+add_test_unit(getenv)
+add_test_unit(logging)

--- a/libsupport/test/getenv.cpp
+++ b/libsupport/test/getenv.cpp
@@ -1,0 +1,20 @@
+#include "galois/GetEnv.h"
+#include "galois/Logging.h"
+
+int main() {
+  GALOIS_LOG_ASSERT(galois::GetEnv("PATH"));
+
+  std::string s;
+  GALOIS_LOG_ASSERT(galois::GetEnv("PATH", &s));
+
+  int i{};
+  GALOIS_LOG_ASSERT(!galois::GetEnv("PATH", &i));
+
+  double d{};
+  GALOIS_LOG_ASSERT(!galois::GetEnv("PATH", &d));
+
+  bool b{};
+  GALOIS_LOG_ASSERT(!galois::GetEnv("PATH", &b));
+
+  return 0;
+}

--- a/libsupport/test/logging.cpp
+++ b/libsupport/test/logging.cpp
@@ -1,0 +1,20 @@
+#include "galois/Logging.h"
+
+#include <system_error>
+
+int main() {
+  GALOIS_LOG_ERROR("string");
+  GALOIS_LOG_ERROR("format string: {}", 42);
+  GALOIS_LOG_ERROR("format string: {:d}", 42);
+  // The following correctly fails with a compile time error
+  // GALOIS_LOG_ERROR("basic format string {:s}", 42);
+  GALOIS_LOG_WARN("format number: {:.2f}", 2.0 / 3.0);
+  GALOIS_LOG_WARN("format error code: {}",
+                  std::make_error_code(std::errc::invalid_argument));
+  GALOIS_LOG_VERBOSE(
+      "will be printed when environment variable GALOIS_LOG_VERBOSE=1");
+  GALOIS_LOG_DEBUG("this will only be printed in debug builds");
+  GALOIS_LOG_ASSERT(1 == 1);
+
+  return 0;
+}

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get install -qy \
       gcc-9 \
       git \
       gosu \
+      libfmt-dev \
       libopenmpi-dev \
       llvm-10-dev \
       python3-pip \


### PR DESCRIPTION
Rebase of https://github.com/KatanaGraph/katana/pull/75 for upstream :heart: 

Biggest design question was the addition of custom formatting for error codes in Logging.h:
https://github.com/IntelligentSoftwareSystems/Galois/pull/325/files#diff-c6650dc73c3e5f6efb29ab8aaf58bdf1R20

It might be a little unexpected that the linking of std::error_code and fmt happens in `Logging.h` but I couldn't think of a better place.