### PR TITLE
Lower-level FGW w/ careful memory management

### DIFF
--- a/docs/graphio.dox
+++ b/docs/graphio.dox
@@ -26,7 +26,6 @@ Use galois::graphs::FileGraph::toFile to write a galois::graphs::FileGraph to a 
 <ol>
 <li> Set the number of nodes by calling galois::graphs::FileGraphWriter::setNumNodes.
 <li> Set the number of edges by calling galois::graphs::FileGraphWriter::setNumEdges.
-<li> Set the size of edge data by calling galois::graphs::FileGraphWriter::setSizeofEdgeData.
 <li> Call galois::graphs::FileGraphWriter::phase1 to allocate space for arrays of row pointers, edge destination and edge data.
 <li> Set the degree of each node by calling galois::graphs::FileGraphWriter::incrementDegree for each node.
 <li> Call galois::graphs::FileGraphWriter::phase2 to calculate the prefix sum of node degree to have row pointers.

--- a/docs/graphio.dox
+++ b/docs/graphio.dox
@@ -25,12 +25,12 @@ If you want to load a .gr (binary Galois graph) into your own graph types, then 
 Use galois::graphs::FileGraph::toFile to write a galois::graphs::FileGraph to a binary file. Use galois::graphs::FileGraphWriter to construct a galois::graphs::FileGraph by the following steps:
 <ol>
 <li> Set the number of nodes by calling galois::graphs::FileGraphWriter::setNumNodes.
-<li> Set the number of edges by calling galois::graphs::FileGraphWriter::setNumEdges.
+<li> Set the number of edges and the type of edge data by calling galois::graphs::FileGraphWriter::setNumEdges<EdgeTy>.
 <li> Call galois::graphs::FileGraphWriter::phase1 to allocate space for arrays of row pointers, edge destination and edge data.
 <li> Set the degree of each node by calling galois::graphs::FileGraphWriter::incrementDegree for each node.
 <li> Call galois::graphs::FileGraphWriter::phase2 to calculate the prefix sum of node degree to have row pointers.
-<li> Add edges by calling galois::graphs::FileGraphWriter::addNeighbor for each edge. The function returns for the edge the index into the edge destination array, which can be used to maintain the edge data array if required.
-<li> Call galois::graphs::FileGraphWriter::finish to get a pointer which points to the memory location where the edge data can be saved. Copy the edge data array to the space pointed by the pointer.
+<li> Add edges by calling galois::graphs::FileGraphWriter::addNeighbor for each edge. The function returns for the edge the index into the edge destination array, which can be used to maintain the edge data array if required. Add edges and corresponding edge data at the same time by calling galois::graphs::FileGraphWriter::addNeighbor<EdgeTy>.
+<li> Call galois::graphs::FileGraphWriter::finish. To get a pointer which points to the memory location where the edge data can be saved, call galois::graphs::FileGraphWriter::finish<EdgeTy> instead and copy the edge data array to the space pointed by the pointer.
 </ol>
 
 @section garph_utility Utility Tools for Graphs

--- a/libgalois/include/galois/graphs/FileGraph.h
+++ b/libgalois/include/galois/graphs/FileGraph.h
@@ -671,10 +671,11 @@ public:
  *
  * Writer your file in rounds:
  * <ol>
- *  <li>setNumNodes(), setNumEdges()</li>
+ *  <li>setNumNodes(), setNumEdges<EdgeTy>()</li>
  *  <li>phase1(), for each node, incrementDegree(Node x)</li>
- *  <li>phase2(), add neighbors for each node, addNeighbor(Node src, Node
- *    dst)</li>
+ *  <li>phase2(), add neighbors for each node, addNeighbor(Node src, Node dst),
+ *    or add neighbors and corresponding data, addNeighbor<EdgeTy>(Node src,
+ *    Node dst, EdgeTy data)</li>
  *  <li>finish(), use as FileGraph</li>
  * </ol>
  */

--- a/libgalois/include/galois/graphs/OCGraph.h
+++ b/libgalois/include/galois/graphs/OCGraph.h
@@ -28,6 +28,7 @@
 
 #include "galois/config.h"
 #include "galois/graphs/Details.h"
+#include "galois/substrate/PageAlloc.h"
 #include "galois/LazyObject.h"
 #include "galois/LargeArray.h"
 #include "galois/optional.h"
@@ -149,12 +150,6 @@ public:
   };
 
 private:
-#ifdef HAVE_MMAP64
-  typedef off64_t offset_t;
-#else
-  typedef off_t offset_t;
-#endif
-
   struct PageSizeConf;
 
   class Block {

--- a/libgalois/include/galois/substrate/PageAlloc.h
+++ b/libgalois/include/galois/substrate/PageAlloc.h
@@ -24,6 +24,41 @@
 
 #include "galois/config.h"
 
+#ifdef __linux__
+#include <linux/mman.h>
+#endif
+#include <sys/mman.h>
+
+#include <utility>
+#ifdef HAVE_MMAP64
+namespace galois {
+template <typename... Args>
+void* mmap(void* addr, Args... args) { // 0 -> nullptr
+  return ::mmap64(addr, std::forward<Args>(args)...);
+}
+} // namespace galois
+//! offset type for mmap
+typedef off64_t offset_t;
+#else
+namespace galois {
+template <typename... Args>
+void* mmap(void* addr, Args... args) { // 0 -> nullptr
+  return ::mmap(addr, std::forward<Args>(args)...);
+}
+} // namespace galois
+//! offset type for mmap
+typedef off_t offset_t;
+#endif
+
+// mmap flags
+#if defined(MAP_ANONYMOUS)
+static const int _MAP_ANON = MAP_ANONYMOUS;
+#elif defined(MAP_ANON)
+static const int _MAP_ANON = MAP_ANON;
+#else
+static_assert(0, "No Anonymous mapping");
+#endif
+
 namespace galois {
 namespace substrate {
 

--- a/libgalois/src/FileGraph.cpp
+++ b/libgalois/src/FileGraph.cpp
@@ -31,42 +31,14 @@
 #include <cassert>
 #include <fstream>
 
-#ifdef __linux__
-#include <linux/mman.h>
-#endif
-#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
 #include <unistd.h>
 
-#if defined(MAP_ANONYMOUS)
-static const int _MAP_ANON = MAP_ANONYMOUS;
-#elif defined(MAP_ANON)
-static const int _MAP_ANON = MAP_ANON;
-#else
-// fail
-#endif
-
 /**
  * Performs an mmap of all provided arguments.
  */
-#ifdef HAVE_MMAP64
-template <typename... Args>
-void* mmap_big(Args... args) {
-  return mmap64(std::forward<Args>(args)...);
-}
-//! offset type for mmap
-typedef off64_t offset_t;
-#else
-template <typename... Args>
-void* mmap_big(Args... args) {
-  return mmap(std::forward<Args>(args)...);
-}
-//! offset type for mmap
-typedef off_t offset_t;
-#endif
-
 namespace galois {
 namespace graphs {
 // Graph file format:
@@ -217,8 +189,8 @@ void* FileGraph::fromArrays(uint64_t* out_idx, uint64_t num_nodes, void* outs,
   size_t bytes =
       rawBlockSize(num_nodes, num_edges, sizeof_edge_data, oGraphVersion);
 
-  char* base = (char*)mmap_big(nullptr, bytes, PROT_READ | PROT_WRITE,
-                               _MAP_ANON | MAP_PRIVATE, -1, 0);
+  char* base = (char*)mmap(nullptr, bytes, PROT_READ | PROT_WRITE,
+                           _MAP_ANON | MAP_PRIVATE, -1, 0);
   if (base == MAP_FAILED)
     GALOIS_SYS_DIE("failed allocating graph");
 
@@ -313,7 +285,7 @@ void FileGraph::fromFile(const std::string& filename) {
 #ifdef MAP_POPULATE
   _MAP_BASE |= MAP_POPULATE;
 #endif
-  void* base = mmap_big(nullptr, buf.st_size, PROT_READ, _MAP_BASE, fd, 0);
+  void* base = mmap(nullptr, buf.st_size, PROT_READ, _MAP_BASE, fd, 0);
   if (base == MAP_FAILED)
     GALOIS_SYS_DIE("failed reading ", "'", filename, "'");
   mappings.push_back({base, static_cast<size_t>(buf.st_size)});
@@ -338,7 +310,7 @@ static void* loadFromOffset(int fd, offset_t offset, size_t length,
       offset & ~static_cast<offset_t>(galois::substrate::allocSize() - 1);
   offset_t alignment = offset - aligned;
   length += alignment;
-  void* base = mmap_big(nullptr, length, PROT_READ, MAP_PRIVATE, fd, aligned);
+  void* base = mmap(nullptr, length, PROT_READ, MAP_PRIVATE, fd, aligned);
   if (base == MAP_FAILED)
     GALOIS_SYS_DIE("failed allocating for fd ", fd);
   mappings.push_back({base, length});
@@ -738,7 +710,7 @@ void FileGraphWriter::phase1() {
 
   size_t bytes    = galois::graphs::rawBlockSize(numNodes, numEdges, sizeofEdge,
                                               graphVersion);
-  char* mmap_base = reinterpret_cast<char*>(mmap_big(
+  char* mmap_base = reinterpret_cast<char*>(mmap(
       nullptr, bytes, PROT_READ | PROT_WRITE, _MAP_ANON | MAP_PRIVATE, -1, 0));
   if (mmap_base == MAP_FAILED)
     GALOIS_SYS_DIE("failed allocating graph to write");

--- a/libgalois/src/OCFileGraph.cpp
+++ b/libgalois/src/OCFileGraph.cpp
@@ -24,10 +24,6 @@
 #include <cassert>
 
 #include <fcntl.h>
-#ifdef __linux__
-#include <linux/mman.h>
-#endif
-#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -43,18 +39,6 @@ using namespace galois::graphs;
 // outedges[numEdges] {uint32_t LE}
 // potential padding (32bit max) to Re-Align to 64bits
 // EdgeType[numEdges] {EdgeType size}
-
-#ifdef HAVE_MMAP64
-template <typename... Args>
-void* mmap_big(Args... args) {
-  return mmap64(std::forward<Args>(args)...);
-}
-#else
-template <typename... Args>
-void* mmap_big(Args... args) {
-  return mmap(std::forward<Args>(args)...);
-}
-#endif
 
 OCFileGraph::~OCFileGraph() {
   if (masterMapping)
@@ -88,7 +72,7 @@ void OCFileGraph::Block::load(int fd, offset_t offset, size_t begin, size_t len,
   m_length =
       len * sizeof_data +
       galois::runtime::pagePoolSize(); // account for round off due to alignment
-  m_mapping = mmap_big(nullptr, m_length, PROT_READ, _MAP_BASE, fd, aligned);
+  m_mapping = mmap(nullptr, m_length, PROT_READ, _MAP_BASE, fd, aligned);
   if (m_mapping == MAP_FAILED) {
     GALOIS_SYS_DIE("failed allocating ", fd);
   }

--- a/libgalois/src/PageAlloc.cpp
+++ b/libgalois/src/PageAlloc.cpp
@@ -23,11 +23,6 @@
 
 #include <mutex>
 
-#ifdef __linux__
-#include <linux/mman.h>
-#endif
-#include <sys/mman.h>
-
 // figure this out dynamically
 const size_t hugePageSize = 2 * 1024 * 1024;
 // protect mmap, munmap since linux has issues
@@ -36,19 +31,11 @@ static galois::substrate::SimpleLock allocLock;
 static void* trymmap(size_t size, int flag) {
   std::lock_guard<galois::substrate::SimpleLock> lg(allocLock);
   const int _PROT = PROT_READ | PROT_WRITE;
-  void* ptr       = mmap(0, size, _PROT, flag, -1, 0);
+  void* ptr       = galois::mmap(0, size, _PROT, flag, -1, 0);
   if (ptr == MAP_FAILED)
     ptr = nullptr;
   return ptr;
 }
-// mmap flags
-#if defined(MAP_ANONYMOUS)
-static const int _MAP_ANON = MAP_ANONYMOUS;
-#elif defined(MAP_ANON)
-static const int _MAP_ANON     = MAP_ANON;
-#else
-static_assert(0, "No Anonymous mapping");
-#endif
 
 static const int _MAP = _MAP_ANON | MAP_PRIVATE;
 #ifdef MAP_POPULATE

--- a/lonestar/analytics/cpu/matching/bipartite-mcm.cpp
+++ b/lonestar/analytics/cpu/matching/bipartite-mcm.cpp
@@ -1012,8 +1012,7 @@ void generateRandomInput(int numA, int numB, int numEdges, int numGroups,
 
   galois::graphs::FileGraphWriter p;
   p.setNumNodes(numA + numB);
-  p.setNumEdges(numEdges);
-  p.setSizeofEdgeData(galois::LargeArray<edge_data_type>::size_of::value);
+  p.setNumEdges<edge_data_type>(numEdges);
 
   for (int phase = 0; phase < 2; ++phase) {
     if (phase == 0)

--- a/lonestar/analytics/cpu/preflowpush/Preflowpush.cpp
+++ b/lonestar/analytics/cpu/preflowpush/Preflowpush.cpp
@@ -581,8 +581,7 @@ struct PreflowPush {
     }
 
     p.setNumNodes(reader.size());
-    p.setNumEdges(numEdges);
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(numEdges);
 
     p.phase1();
     for (ReaderGraph::iterator ii = reader.begin(), ei = reader.end(); ii != ei;

--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -424,8 +424,7 @@ void convertEdgelist(const std::string& infilename,
 
   numNodes++;
   p.setNumNodes(numNodes);
-  p.setNumEdges(numEdges);
-  p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+  p.setNumEdges<EdgeTy>(numEdges);
 
   infile.clear();
   infile.seekg(0, std::ios::beg);
@@ -680,8 +679,7 @@ struct Mtx2Gr : public HasNoVoidSpecialization {
       // Parse edges
       if (phase == 0) {
         p.setNumNodes(nnodes);
-        p.setNumEdges(nedges);
-        p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+        p.setNumEdges<EdgeTy>(nedges);
         p.phase1();
       } else {
         p.phase2();
@@ -795,7 +793,7 @@ struct Nodelist2Gr : public HasOnlyVoidSpecialization {
 
     numNodes++;
     p.setNumNodes(numNodes);
-    p.setNumEdges(numEdges);
+    p.setNumEdges<void>(numEdges);
 
     infile.clear();
     infile.seekg(0, std::ios::beg);
@@ -1210,8 +1208,7 @@ struct AddRing : public Conversion {
     uint64_t size     = graph.size();
     uint64_t newEdges = AddLine ? size - 1 : size;
     p.setNumNodes(size);
-    p.setNumEdges(graph.sizeEdges() + newEdges);
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(graph.sizeEdges() + newEdges);
 
     p.phase1();
     for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei; ++ii) {
@@ -1284,8 +1281,7 @@ struct AddTree : public Conversion {
       newEdges *= 2; // reverse edges
 
     p.setNumNodes(size);
-    p.setNumEdges(graph.sizeEdges() + newEdges);
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(graph.sizeEdges() + newEdges);
 
     p.phase1();
     for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei; ++ii) {
@@ -1619,8 +1615,7 @@ struct RemoveHighDegree : public Conversion {
     }
 
     p.setNumNodes(numNodes);
-    p.setNumEdges(numEdges);
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(numEdges);
 
     p.phase1();
     for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei; ++ii) {
@@ -1686,8 +1681,7 @@ struct PartitionBySource : public Conversion {
                                  graph.edge_end(*(r.second - 1)));
 
       p.setNumNodes(graph.size());
-      p.setNumEdges(numEdges);
-      p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+      p.setNumEdges<EdgeTy>(numEdges);
 
       p.phase1();
       for (Graph::iterator ii = r.first, ei = r.second; ii != ei; ++ii) {
@@ -1784,8 +1778,7 @@ struct PartitionByDestination : public Conversion {
       }
 
       p.setNumNodes(graph.size());
-      p.setNumEdges(numEdges);
-      p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+      p.setNumEdges<EdgeTy>(numEdges);
 
       p.phase1();
       for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei;
@@ -1847,8 +1840,7 @@ struct Transpose : public Conversion {
     Writer p;
 
     p.setNumNodes(graph.size());
-    p.setNumEdges(graph.sizeEdges());
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(graph.sizeEdges());
 
     p.phase1();
     for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei; ++ii) {
@@ -1952,8 +1944,7 @@ struct Cleanup : public Conversion {
     Writer p;
 
     p.setNumNodes(graph.size());
-    p.setNumEdges(numEdges);
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(numEdges);
 
     p.phase1();
     for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei; ++ii) {
@@ -2068,8 +2059,7 @@ struct MakeUnsymmetric : public Conversion {
     Writer p;
 
     p.setNumNodes(graph.size());
-    p.setNumEdges(numEdges);
-    p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+    p.setNumEdges<EdgeTy>(numEdges);
 
     p.phase1();
     for (Graph::iterator ii = graph.begin(), ei = graph.end(); ii != ei; ++ii) {
@@ -2160,8 +2150,7 @@ struct Dimacs2Gr : public HasNoVoidSpecialization {
       // Parse edges
       if (phase == 0) {
         p.setNumNodes(nnodes);
-        p.setNumEdges(nedges);
-        p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+        p.setNumEdges<EdgeTy>(nedges);
         p.phase1();
       } else {
         p.phase2();
@@ -2249,7 +2238,7 @@ struct Pbbs2Gr : public HasOnlyVoidSpecialization {
     }
 
     p.setNumNodes(nnodes);
-    p.setNumEdges(nedges);
+    p.setNumEdges<void>(nedges);
 
     size_t* offsets = new size_t[nnodes];
     for (size_t i = 0; i < nnodes; ++i) {
@@ -2883,8 +2872,7 @@ struct Svmlight2Gr : public HasNoVoidSpecialization {
         featureOffset = numNodes;
         numNodes += maxFeature + 1;
         p.setNumNodes(numNodes);
-        p.setNumEdges(numEdges);
-        p.setSizeofEdgeData(SizeOf<EdgeTy>::value);
+        p.setNumEdges<EdgeTy>(numEdges);
         p.phase1();
       } else if (phase == 1) {
         p.phase2();

--- a/tools/graph-remap/graph-remap.cpp
+++ b/tools/graph-remap/graph-remap.cpp
@@ -76,7 +76,7 @@ int main(int argc, char** argv) {
 
   Writer graphWriter;
   graphWriter.setNumNodes(remapper.size());
-  graphWriter.setNumEdges(graphToRemap.sizeEdges());
+  graphWriter.setNumEdges<void>(graphToRemap.sizeEdges());
 
   // phase 1: count degrees
   graphWriter.phase1();
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
 
   galois::gInfo("Finishing up: outputting graph shortly");
 
-  graphWriter.finish<void>();
+  graphWriter.finish();
   graphWriter.toFile(outputFilename);
 
   galois::gInfo("new size is ", graphWriter.size(), " num edges ",


### PR DESCRIPTION
The current FileGraphWriter does wild memory management: to construct a new graph (from an old graph, e.g. make symmetric, or not), it first builds up `std::vector`s in CSR format, then `memcpy` them to `mmap`'ed space, then reads the data back to the fields inherited from FileGraph, and finally constructs the new graph by the FileGraph. Memory usage is double the size of the new graph, which is bad esp. when the graph is large (in my case, I'm synthesizing regular grids).

I initiated a new FileGraphWriter implementation, namely FileGraphWeaver so that it may co-exist with the old one or replace the old FGW later, which has the same APIs (means least efforts on other code if it replaces the old impl.) but does mmap directly without memcpy.

---

EDIT: The changes are in-place now.

As a reminder for discussion: Should FileGraphWriter be a `friend` instead of a child of FileGraph? They in fact share the same data fields which are private in FileGraph and re-declared in FileGraphWriter. Making these fields protected is a solution but does not seem to be a good practice just in order to expose them to a specific subclass.