### PR TITLE
Fix operator precedence bug in OBIM.

### DIFF
--- a/libgalois/include/galois/worklists/Obim.h
+++ b/libgalois/include/galois/worklists/Obim.h
@@ -405,7 +405,7 @@ public:
       return this->popStored(p, p.curIndex);
 
     if (!UseBarrier && BlockPeriod &&
-        (p.numPops++ & ((1 << BlockPeriod) - 1)) == 0)
+        ((p.numPops++ & ((1 << BlockPeriod) - 1)) == 0))
       return slowPop(p);
 
     galois::optional<value_type> item;


### PR DESCRIPTION
The == operator actually has higher precedence than the bitwise & operator in C++, so our handling of the BlockPeriod template parameter was actually wrong. This adds clarifying parentheses to get the right result. I'm not yet sure what the performance consequences of this change are.

I noticed this while preparing https://github.com/IntelligentSoftwareSystems/Galois/pull/342. It's a really old bug. I only found it because of a new gcc warning.