### PR TITLE
Fix broken barrier in DistStats

### DIFF
--- a/libdist/include/galois/DTerminationDetector.h
+++ b/libdist/include/galois/DTerminationDetector.h
@@ -150,10 +150,8 @@ public:
 
   bool terminate() {
     bool active = (local_mdata != 0);
-    // if (active) galois::gDebug("[", net.ID, "] local work done \n");
     if (!active) {
       active = net.anyPendingSends();
-      // if (active) galois::gDebug("[", net.ID, "] pending send \n");
     }
     int snapshot_ended = 0;
     if (!active) {

--- a/libdist/src/DistStats.cpp
+++ b/libdist/src/DistStats.cpp
@@ -286,13 +286,18 @@ void DistStatManager::combineAtHost_0(void) {
   combineAtHost_0_helper();
   getSystemNetworkInterface().flush();
 
+  // work done before check
+  td += 1;
+
   // barrier
   while (td.reduce()) {
+    td.reset();
     if (getHostID() == 0) {
       // receive from other hosts
       receiveAtHost_0_helper();
     }
-  };
+  }
+
   // explicit barrier after logical barrier is required
   // as next async phase begins immediately
   getHostBarrier().wait();
@@ -302,13 +307,18 @@ void DistStatManager::combineAtHost_0(void) {
   combineAtHost_0_helper2();
   getSystemNetworkInterface().flush();
 
+  td += 1;
+
   // barrier
   while (td.reduce()) {
+    td.reset();
+
     if (getHostID() == 0) {
       // receive from other hosts
       receiveAtHost_0_helper2();
     }
-  };
+  }
+
   // explicit barrier after logical barrier is required
   // as next async phase begins immediately
   getHostBarrier().wait();


### PR DESCRIPTION
Shamelessly stolen from KatanaGraph.

Fixes an issue where host 0 can stay in termination detection because it
detects work after other hosts have decided that they are done with
termination detection.