### PR TITLE
fix a bug that graph-convert does not work for graph with less than 5…

### DIFF
--- a/tools/graph-convert/graph-convert.cpp
+++ b/tools/graph-convert/graph-convert.cpp
@@ -686,7 +686,7 @@ struct Mtx2Gr : public HasNoVoidSpecialization {
       }
 
       for (size_t edge_num = 0; edge_num < nedges; ++edge_num) {
-        if ((edge_num % (nedges / 500)) == 0) {
+        if ( (nedges / 500 > 0) && (edge_num % (nedges / 500)) == 0) {
           printf("Phase %d: current edge progress %lf%%\n", phase,
                  ((double)edge_num / nedges) * 100);
         }


### PR DESCRIPTION
When I tried to use graph-convert to convert a small graph from mtx to gr format, the graph-convert tool does not work. The error message was `Floating point exception (core dumped)`. 

The bug was in graph-convert.cpp:689. This commit is an easy fix for this problem. 
